### PR TITLE
Decode UTF-8 chars in old style library files

### DIFF
--- a/resources/lib/kodi/library.py
+++ b/resources/lib/kodi/library.py
@@ -380,7 +380,7 @@ def _lib_folders(section):
 
 def _get_root_videoid(filename, pattern):
     match = re.search(pattern,
-                      xbmcvfs.File(filename, 'r').read().split('\n')[-1])
+                      xbmcvfs.File(filename, 'r').read().decode('utf-8').split('\n')[-1])
     metadata = api.metadata(
         common.VideoId(videoid=match.groups()[0]))[0]
     if metadata['type'] == 'show':


### PR DESCRIPTION
Solve a problem migrating old style library files with non-ascii characters in film/series name, according to bug report in issue #16 