### PR TITLE
Fix sort order for MyList: Series and Movies are not separated anymor…

### DIFF
--- a/resources/lib/kodi/listings.py
+++ b/resources/lib/kodi/listings.py
@@ -260,7 +260,7 @@ def build_video_listing(video_list, menu_data, pathitems=None, genre_id=None):
     # so we adding the sort order of kodi
     sort_type = 'sort_nothing'
     if menu_data['path'][1] == 'myList':
-        sort_type = 'sort_label'
+        sort_type = 'sort_label_ignore_folders'
     finalize_directory(directory_items, menu_data.get('content_type', g.CONTENT_SHOW),
                        title=g.get_menu_title(menu_data['path'][1]), sort_type=sort_type)
     return menu_data.get('view')
@@ -399,6 +399,8 @@ def add_sort_methods(sort_type):
         xbmcplugin.addSortMethod(g.PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_NONE)
     if sort_type == 'sort_label':
         xbmcplugin.addSortMethod(g.PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
+    if sort_type == 'sort_label_ignore_folders':
+        xbmcplugin.addSortMethod(g.PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_LABEL_IGNORE_FOLDERS)
     if sort_type == 'sort_episodes':
         xbmcplugin.addSortMethod(g.PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_EPISODE)
         xbmcplugin.addSortMethod(g.PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_LABEL)


### PR DESCRIPTION
Fix sort order for MyList: Series and Movies are not separated anymore. Better for navigation with remote using keys 1-9

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

