### PR TITLE
Fix StreamContinuity

### DIFF
--- a/resources/lib/services/playback/stream_continuity.py
+++ b/resources/lib/services/playback/stream_continuity.py
@@ -79,7 +79,7 @@ class StreamContinuityManager(PlaybackActionManager):
                 common.debug('{} has changed from {} to {}'
                              .format(stype, current_stream, player_stream))
                 self._set_current_stream(stype, player_state)
-                self._save_changed_stream(stype, player_stream)
+                self._save_all_streams(player_state, stype, player_stream)
 
     def _set_current_stream(self, stype, player_state):
         self.current_streams.update({
@@ -99,10 +99,12 @@ class StreamContinuityManager(PlaybackActionManager):
             self.current_streams[stype] = stored_stream
             common.debug('Restored {} to {}'.format(stype, stored_stream))
 
-    def _save_changed_stream(self, stype, stream):
-        common.debug('Save changed stream {} for {}'.format(stream, stype))
-        new_show_settings = self.show_settings.copy()
-        new_show_settings[stype] = stream
+    def _save_all_streams(self, player_state, stype, stream):
+        common.debug('Save all streams because a change of {} for {}'.format(stream, stype))
+        new_show_settings={}
+        for stype in STREAMS:
+            player_stream = player_state.get(STREAMS[stype]['current'])
+            new_show_settings[stype] = player_stream
         self.storage[self.current_videoid] = new_show_settings
         self.storage.commit()
 


### PR DESCRIPTION
Under certain circumstances and since the 'Forced Subtitles' workaround is implemented, Kodi may not select the correct subtitle stream, on Rapsberry Pi mostly.
It then select the last subtitle, instead of the one we may want, especially if only if the 'show subtitle' setting was changed.
Saving all streams settings if anything change will ensure StreamContinuity to restore everything as chosen.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

