### PR TITLE
Fix library export path

### DIFF
--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -743,3 +743,51 @@ msgstr "Pas de bande annonce"
 msgctxt "#30181"
 msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to \"Only forced\" subtitles)"
 msgstr "Désactiver les sous-titres s'il n'y a pas de piste forcée (Fonctionne seulement si Kodi est configuré sur \"Forcé seulement\" pour les sous-titres"
+
+msgctxt "#30282"
+msgid "Export NFO files"
+msgstr "Exporter les fichiers NFO"
+
+msgctxt "#30283"
+msgid "Do you want to export NFO files for the {}?"
+msgstr "Voulez-vous exporter les fichiers NFO pour {} ?"
+
+msgctxt "#30284"
+msgid "NFO Files"
+msgstr "Fichiers NFO"
+
+msgctxt "#30285"
+msgid "Enable NFO files export"
+msgstr "Activer l'export des fichiers NFO"
+
+msgctxt "#30286"
+msgid "For Movies"
+msgstr "Pour les Films"
+
+msgctxt "#30287"
+msgid "For TV Show"
+msgstr "Pour les Séries Télé"
+
+msgctxt "#30288"
+msgid "Ask"
+msgstr "Demander"
+
+msgctxt "#30289"
+msgid "movie"
+msgstr "le film"
+
+msgctxt "#30290"
+msgid "TV show"
+msgstr "la série télé"
+
+msgctxt "#30291"
+msgid "Do you want to export NFO files for the {} added to 'My List'?"
+msgstr "Voulez-vous exporter les fichiers NFO pour {} ajouté à 'Ma Liste' ?"
+
+msgctxt "#30292"
+msgid "\r\nThese files are used by the provider information scrapers to integrate movies and tv shows info, useful with bonus episodes or director's cut"
+msgstr "\r\nCes fichiers sont utilisés par le fournisseur d'information pour intégrer les infos des films et des séries télé. Utile pour des épisodes bonus ou des découpages spéciaux"
+
+msgctxt "#30293"
+msgid "Include all information in NFO files (use only with 'Local Information' scraper)"
+msgstr "Inclure toutes les informations dans les fichiers NFO (utiliser uniquement avec le fournisseur d'information 'Local Information only')"

--- a/resources/lib/kodi/library.py
+++ b/resources/lib/kodi/library.py
@@ -275,13 +275,13 @@ def export_item(item_task, library_home):
         library_home, item_task['section'], item_task['destination']))
     _create_destination_folder(destination_folder)
     if item_task['is_strm']:
-        export_filename = xbmc.makeLegalFilename(os.path.join(
-            destination_folder.decode('utf-8'), item_task['filename'] + '.strm'))
+        export_filename = xbmc.makeLegalFilename('/'.join(
+            [destination_folder.decode('utf-8'), item_task['filename'] + '.strm']))
         _add_to_library(item_task['videoid'], export_filename)
         _write_strm_file(item_task, export_filename)
     if item_task['nfo_data'] is not None:
-        nfo_filename = xbmc.makeLegalFilename(os.path.join(
-            destination_folder.decode('utf-8'), item_task['filename'] + '.nfo'))
+        nfo_filename = xbmc.makeLegalFilename('/'.join(
+            [destination_folder.decode('utf-8'), item_task['filename'] + '.nfo']))
         _write_nfo_file(item_task['nfo_data'], nfo_filename)
     common.debug('Exported {}'.format(item_task['title']))
 


### PR DESCRIPTION
os.path.join under windows uses a ' \ ' to join, but it can break the names if they contains special characters as '%'
Using '/' for join fixes the issue, and xbmc.makeLegalFilename will translate '/' to ' \ ' for pure windows folders

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

## Screenshots (if appropriate):

[You can erase any parts of this template not applicable to your Pull Request.]
