### PR TITLE
Stream Resolution Selection

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1,13 +1,13 @@
 # Kodi Media Center language file
 # Addon Name: Netflix
 # Addon id: plugin.video.netflix
-# Addon Provider: libdev + jojo + asciidisco + caphm + CastagnaIT
+# Addon Provider: libdev + jojo + asciidisco
 msgid ""
 msgstr ""
 "Project-Id-Version: plugin.video.netflix\n"
 "Report-Msgid-Bugs-To: https://github.com/CastagnaIT/plugin.video.netflix\n"
 "POT-Creation-Date: 2017-07-24 16:15+0000\n"
-"PO-Revision-Date: 2019-07-08 22:15+0000\n"
+"PO-Revision-Date: 2017-07-24 16:15+0000\n"
 "Last-Translator: Stefano Gottardo <>\n"
 "Language-Team: English\n"
 "MIME-Version: 1.0\n"
@@ -565,7 +565,7 @@ msgid "Enable 1080p Unlock (not recommended for Android)"
 msgstr ""
 
 msgctxt "#30137"
-msgid "Enable VP9 profiles (disable if it causes artifacts)"
+msgid "Enable VP9 profiles (not use with HEVC, disable if it causes artifacts)"
 msgstr ""
 
 msgctxt "#30138"
@@ -709,7 +709,7 @@ msgid "Popular on Netflix"
 msgstr ""
 
 msgctxt "#30173"
-msgid "Netflix Originals"
+msgid "NETFLIX ORIGINALS"
 msgstr ""
 
 msgctxt "#30174"
@@ -790,4 +790,36 @@ msgstr ""
 
 msgctxt "#30193"
 msgid "Include all information in NFO files (use only with 'Local Information' scraper)"
+msgstr ""
+
+msgctxt "#30194"
+msgid "Stream Type"
+msgstr ""
+
+msgctxt "#30195"
+msgid "Video Strem Type (Up to...)"
+msgstr ""
+
+msgctxt "#30196"
+msgid "SD"
+msgstr ""
+
+msgctxt "#30197"
+msgid "640"
+msgstr ""
+
+msgctxt "#30198"
+msgid "720p"
+msgstr ""
+
+msgctxt "#30199"
+msgid "1080p"
+msgstr ""
+
+msgctxt "#30200"
+msgid "4k"
+msgstr ""
+
+msgctxt "#30201"
+msgid "Minimal Available"
 msgstr ""

--- a/resources/lib/services/msl/profiles.py
+++ b/resources/lib/services/msl/profiles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """MSL video profiles"""
 from __future__ import unicode_literals
-
+import xbmc
 import xbmcaddon
 
 from resources.lib.globals import g
@@ -20,8 +20,8 @@ VP9_PROFILE2 = 'vp9-profile2-'
 
 BASE_LEVELS = ['L30-', 'L31-', 'L40-', 'L41-', 'L50-', 'L51-']
 CENC_TL_LEVELS = ['L30-L31-', 'L31-L40-', 'L40-L41-', 'L50-L51-']
-VP9_PROFILE0_LEVELS = ['L21-', 'L30-', 'L31-', 'L40-']
-VP9_PROFILE2_LEVELS = ['L30-', 'L31-', 'L40-', 'L50-', 'L51-']
+VP9_PROFILE0_LEVELS = ['L10-', 'L11-', 'L20-', 'L21-', 'L30-', 'L31-', 'L40-','L41-',  'L50-', 'L51-','L52-','L60-','L61-', 'L62-']
+VP9_PROFILE2_LEVELS = ['L10-', 'L11-', 'L20-', 'L21-', 'L30-', 'L31-', 'L40-','L41-',  'L50-', 'L51-','L52-','L60-','L61-', 'L62-']
 
 
 def _profile_strings(base, tails):
@@ -38,10 +38,17 @@ PROFILES = {
         # Unknown
         'BIF240', 'BIF320'],
     'dolbysound': ['ddplus-2.0-dash', 'ddplus-5.1-dash', 'ddplus-5.1hq-dash', 'ddplus-atmos-dash'],
-    'h264': ['playready-h264mpl30-dash', 'playready-h264mpl31-dash',
-             'playready-h264mpl40-dash',
-             'playready-h264hpl30-dash', 'playready-h264hpl31-dash',
-             'playready-h264hpl40-dash'],
+    'h264': [
+            'playready-h264bpl30-dash',
+            'playready-h264hpl30-dash',
+            'playready-h264mpl30-dash',
+            'playready-h264bpl31-dash',
+            'playready-h264mpl31-dash',
+            'playready-h264hpl31-dash',
+            'playready-h264hpl40-dash',
+            'playready-h264mpl40-dash',
+            'playready-h264bpl40-dash',            
+            ],
     'hevc':
         _profile_strings(base=HEVC,
                          tails=[(BASE_LEVELS, CENC),
@@ -70,7 +77,7 @@ PROFILES = {
 
 def enabled_profiles():
     """Return a list of all base and enabled additional profiles"""
-    return (PROFILES['base'] +
+    profile_list =  (PROFILES['base'] +
             PROFILES['h264'] +
             _subtitle_profiles() +
             _additional_profiles('vp9profile0', 'enable_vp9_profiles') +
@@ -83,6 +90,7 @@ def enabled_profiles():
             _additional_profiles('dolbyvision',
                                  ['enable_hevc_profiles',
                                   'enable_dolbyvision_profiles']))
+    return profile_list
 
 
 def _subtitle_profiles():

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -100,7 +100,7 @@
     <setting id="forced_subtitle_workaround" type="bool" label="30181" default="true" />
   </category>
   <category label="30023"><!--Expert-->
-    <setting label="30115" type="lsep"/>
+    <setting id="StreamType" type="enum" label="30195" lvalues="30196|30197|30198|30199|30200|30201" default="0"/>
     <setting id="enable_1080p_unlock" type="bool" label="30136" default="false" visible="false"/> <!-- Deprecated (broken) -->
     <setting id="enable_dolby_sound" type="bool" label="30033" default="true"/>
     <setting id="enable_vp9_profiles" type="bool" label="30137" enable="eq(1,false)|eq(0,true)" default="true"/>


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [ x] Have you followed the guidelines in our Contributing document?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you successfully ran tests with your changes locally?

## Screenshots (if appropriate):

[You can erase any parts of this template not applicable to your Pull Request.]
In order to limit the resolution of playback, I modified the proc that generates the MPD file that ISH uses, It select all available  resolutions below and inclusive the limit, if nothing found there is a fallback to the lowest available resolution.

I just add suport for SD, 640, 720o, 1080p, 4k....
I also added the option to select the minimun available resolution so it looks for sothing higher than 1 but the lowest available.... 

Hope helps
:)