### PR TITLE
Fix Playback services frozen

### DIFF
--- a/resources/lib/kodi/ui/xmldialogs.py
+++ b/resources/lib/kodi/ui/xmldialogs.py
@@ -11,7 +11,7 @@ import xbmcgui
 ACTION_PLAYER_STOP = 13
 OS_MACHINE = machine()
 
-CMD_AUTOCLOSE_DIALOG = 'AlarmClock(closedialog,Dialog.Close(all,true),' \
+CMD_CLOSE_DIALOG_BY_NOOP = 'AlarmClock(closedialog,Action(noop),' \
                        '{:02d}:{:02d},silent)'
 
 
@@ -25,7 +25,7 @@ def show_modal_dialog(dlg_class, xml, path, **kwargs):
     minutes = kwargs.get('minutes', 0)
     seconds = kwargs.get('seconds', 0)
     if minutes > 0 or seconds > 0:
-        xbmc.executebuiltin(CMD_AUTOCLOSE_DIALOG.format(minutes, seconds))
+        xbmc.executebuiltin(CMD_CLOSE_DIALOG_BY_NOOP.format(minutes, seconds))
     dlg.doModal()
 
 
@@ -48,6 +48,10 @@ class Skip(xbmcgui.WindowXMLDialog):
     def onClick(self, controlID):
         if controlID == 6012:
             xbmc.Player().seekTime(self.skip_to)
+            self.close()
+
+    def onAction(self, action):
+        if action.getId() == 999: # action noop
             self.close()
 
 


### PR DESCRIPTION
https://github.com/CastagnaIT/plugin.video.netflix/issues/130

Sending 'noop' action allows the modal window to close correctly, and the service to keep running

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?
