### PR TITLE
Fix auto login disabled issue

### DIFF
--- a/resources/lib/navigation/directory.py
+++ b/resources/lib/navigation/directory.py
@@ -39,7 +39,7 @@ class DirectoryBuilder(object):
             common.debug('Performing auto-login for selected profile {}'
                          .format(profile_id))
             api.activate_profile(profile_id)
-            self.home()
+            self.home(None, False)
         else:
             self.profiles()
 
@@ -51,12 +51,12 @@ class DirectoryBuilder(object):
         _handle_endofdirectory(False)
 
     @common.time_execution(immediate=False)
-    def home(self, pathitems=None):
+    def home(self, pathitems=None, cache_to_disc=True):
         """Show home listing"""
         # pylint: disable=unused-argument
         common.debug('Showing root video lists')
         listings.build_main_menu_listing(api.root_lists())
-        _handle_endofdirectory(False)
+        _handle_endofdirectory(False, cache_to_disc)
 
     @common.time_execution(immediate=False)
     def video_list(self, pathitems):
@@ -199,6 +199,9 @@ def _display_search_results(pathitems, perpetual_range_start, dir_update_listing
         xbmcplugin.endOfDirectory(g.PLUGIN_HANDLE, succeeded=False)
 
 
-def _handle_endofdirectory(dir_update_listing):
+def _handle_endofdirectory(dir_update_listing, cache_to_disc=True):
     # If dir_update_listing=True overwrite the history list, so we can get back to the main page
-    xbmcplugin.endOfDirectory(g.PLUGIN_HANDLE, succeeded=True, updateListing=dir_update_listing)
+    xbmcplugin.endOfDirectory(g.PLUGIN_HANDLE,
+                              succeeded=True,
+                              updateListing=dir_update_listing,
+                              cacheToDisc=cache_to_disc)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,10 +6,10 @@
     <setting id="logout" type="action" label="30017" action="RunPlugin(plugin://plugin.video.netflix/action/logout/)" option="close"/>
     <setting id="adultpin_enable" type="action" label="30062" default="False" action="RunPlugin(plugin://plugin.video.netflix/action/toggle_adult_pin/)" option="close"/>
     <setting label="30053" type="lsep"/>
-    <setting id="autologin_enable" type="bool" label="30054" default="false"/>
+    <setting id="info" type="text" label="30057" default="" enable="false"/>
+    <setting id="autologin_enable" type="bool" label="30054" default="false" enable="eq(0,true)"/>
     <setting id="autologin_user" type="text" label="30055" default="" enable="false" visible="eq(-1,true)" subsetting="true"/>
     <setting id="autologin_id" type="text" label="30056" default="" enable="false" visible="eq(-2,true)" subsetting="true"/>
-    <setting id="info" type="text" label="30057" default="" enable="false" visible="eq(-3,true)"/>
     <setting type="sep"/>
     <setting id="is_settings" type="action" label="30035" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)" option="close"/>
   </category>


### PR DESCRIPTION
Previously, when auto login was disabled, it was necessary to restart the add-on to see profiles again.
Disabling disc cache for the home directory when auto login is active avoid restarting.

Auto login can't be enabled from settings anymore.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

### Notes

Tested under Windows and LibreELEC. performance lost is almost negligible.
