### PR TITLE
[Bug fix] Wrong reference to common.debug() in kodiops

### DIFF
--- a/resources/lib/common/kodiops.py
+++ b/resources/lib/common/kodiops.py
@@ -185,5 +185,5 @@ def _adjust_locale(locale_code, lang_code_without_country_exists):
         if locale_code in locale_conversion_table:
             return locale_conversion_table[locale_code]
         else:
-            common.debug('AdjustLocale - missing mapping conversion for locale: {}'.format(locale_code))
+            debug('AdjustLocale - missing mapping conversion for locale: {}'.format(locale_code))
             return locale_code


### PR DESCRIPTION
The plugin was exiting with an error ("NameError: global name 'common' is not defined") when writing debug output for AdjustLocale.

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you successfully ran tests with your changes locally?
