### PR TITLE
Fix LibraryUpdateService at first run

### DIFF
--- a/resources/lib/services/library_updater.py
+++ b/resources/lib/services/library_updater.py
@@ -96,7 +96,9 @@ class LibraryUpdateService(xbmc.Monitor):
 
 
 def _compute_next_schedule():
-    update_frequency = g.ADDON.getSettingInt('auto_update')
+    # Retrieve 'auto_update' setting value
+    # or None if settings.xml was not created yet, as at first service run
+    update_frequency = g.ADDON.getSettingInt('auto_update') or None
 
     if not update_frequency:
         common.debug('Library auto update scheduled is disabled')


### PR DESCRIPTION
Error was "update_frequency = g.ADDON.getSettingInt('auto_update') TypeError: Invalid setting type"

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?
