### PR TITLE
Fix multiple errors in LibraryUpdateService

### DIFF
--- a/resources/lib/navigation/library.py
+++ b/resources/lib/navigation/library.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import resources.lib.api.shakti as api
 import resources.lib.common as common
+import resources.lib.database.db_utils as db_utils
 import resources.lib.kodi.library as library
 import resources.lib.kodi.nfo as nfo
 import resources.lib.kodi.ui as ui
@@ -140,12 +141,14 @@ class LibraryActionExecutor(object):
 
     def set_autoupdate_device(self, pathitems):
         """Set the current device to manage auto-update of the shared-library (MySQL)"""
-        g.SHARED_DB.set_value('auto_update_device_uuid', common.get_device_uuid())
+        g.SHARED_DB.set_value('auto_update_device_uuid', common.get_device_uuid(),
+                              table=db_utils.TABLE_SHARED_APP_CONF)
         ui.show_notification(common.get_local_string(30209), time=8000)
 
     def check_autoupdate_device(self, pathitems):
         """Check if the current device manage the auto-updates of the shared-library (MySQL)"""
-        uuid = g.SHARED_DB.get_value('auto_update_device_uuid')
+        uuid = g.SHARED_DB.get_value('auto_update_device_uuid',
+                                     table=db_utils.TABLE_SHARED_APP_CONF)
         if uuid is None:
             msg = common.get_local_string(30212)
         else:


### PR DESCRIPTION
- At service very first run, settings.xml is not created yet and throws an error
"update_frequency = g.ADDON.getSettingInt('auto_update') TypeError: Invalid setting type"

- Fix ERROR: [plugin.video.netflix (0)] SQLite error no such table: app_config

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?
