### PR TITLE
Device uuid

### DIFF
--- a/resources/lib/common/__init__.py
+++ b/resources/lib/common/__init__.py
@@ -13,3 +13,4 @@ from .kodiops import *
 from .pathops import *
 from .misc_utils import *
 from .data_conversion import *
+from .uuid_device import *

--- a/resources/lib/common/misc_utils.py
+++ b/resources/lib/common/misc_utils.py
@@ -21,16 +21,6 @@ from .logging import debug, info, error
 from .kodiops import get_local_string
 
 
-def get_device_uuid():
-    """Generate an uuid for the current device based on the device MAC address"""
-    import uuid
-    mac = uuid.getnode()
-    if (mac >> 40) % 2:
-        from platform import node
-        mac = node()
-    return str(uuid.uuid5(uuid.NAMESPACE_DNS, str(mac)))
-
-
 def find(value_to_find, attribute, search_space):
     """Find a video with matching id in a dict or list"""
     for video in search_space:

--- a/resources/lib/common/uuid_device.py
+++ b/resources/lib/common/uuid_device.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Get the UUID of the device"""
+from __future__ import absolute_import, division, unicode_literals
+
+from .logging import debug
+from .misc_utils import get_system_platform
+
+try:  # Python 2
+    from __builtin__ import str as text
+except ImportError:  # Python 3
+    from builtins import str as text
+
+__CRYPT_KEY__ = None
+
+
+def get_crypt_key():
+    """
+    Lazily generate the crypt key and return it
+    """
+    # pylint: disable=global-statement
+    global __CRYPT_KEY__
+    if not __CRYPT_KEY__:
+        __CRYPT_KEY__ = _get_system_uuid()
+    return __CRYPT_KEY__
+
+
+def get_random_uuid():
+    """
+    Generate a random uuid
+    :return: a string of a random uuid
+    """
+    import uuid
+    return text(uuid.uuid4())
+
+
+def _get_system_uuid():
+    """
+    Try to get an uuid from the system, if it's not possible generates a fake uuid
+    :return: an uuid converted to MD5
+    """
+    import uuid
+    uuid_value = None
+    system = get_system_platform()
+    if system in ['windows', 'xbox']:
+        uuid_value = _get_windows_uuid()
+    elif system == 'android':
+        uuid_value = _get_android_uuid()
+    elif system == 'linux':
+        uuid_value = _get_linux_uuid()
+    elif system in ['osx', 'ios']:
+        uuid_value = _get_macos_uuid()
+    if not uuid_value:
+        debug('It is not possible to get a system UUID creating a new UUID')
+        uuid_value = _get_fake_uuid(system != 'android')
+    return uuid.uuid5(uuid.NAMESPACE_DNS, text(uuid_value)).bytes
+
+
+def _get_windows_uuid():
+    # pylint: disable=broad-except
+    # pylint: disable=no-member
+    uuid_value = None
+    try:
+        try:  # Python 2
+            import _winreg as winreg
+        except ImportError:  # Python 3
+            import winreg as winreg
+        registry = winreg.HKEY_LOCAL_MACHINE
+        address = 'SOFTWARE\\Microsoft\\Cryptography'
+        keyargs = winreg.KEY_READ | winreg.KEY_WOW64_64KEY
+        key = winreg.OpenKey(registry, address, 0, keyargs)
+        value = winreg.QueryValueEx(key, 'MachineGuid')
+        winreg.CloseKey(key)
+        uuid_value = value[0]
+    except Exception:
+        pass
+    if not uuid_value:
+        try:
+            import subprocess
+            output = subprocess.check_output(['vol', 'c:'])
+            output = output.split()
+            uuid_value = output[len(output) - 1:]
+        except Exception:
+            pass
+    return uuid_value
+
+
+def _get_linux_uuid():
+    # pylint: disable=broad-except
+    import subprocess
+    uuid_value = None
+    try:
+        uuid_value = subprocess.check_output(['cat', '/var/lib/dbus/machine-id']).decode('utf-8')
+    except Exception:
+        pass
+    if not uuid_value:
+        try:
+            # Fedora linux
+            uuid_value = subprocess.check_output(['cat', '/etc/machine-id']).decode('utf-8')
+        except Exception:
+            pass
+    return uuid_value
+
+
+def _get_android_uuid():
+    # pylint: disable=broad-except
+    import subprocess
+    import re
+    values = ''
+    try:
+        # Due to the new android security we cannot get any type of serials
+        sys_prop = ['ro.product.board', 'ro.product.brand', 'ro.product.device', 'ro.product.locale'
+                    'ro.product.manufacturer', 'ro.product.model', 'ro.product.platform',
+                    'persist.sys.timezone', 'persist.sys.locale', 'net.hostname']
+        # Warning net.hostname property starting from android 10 is deprecated return empty
+        proc = subprocess.Popen(['/system/bin/getprop'], stdout=subprocess.PIPE)
+        output_data = proc.stdout.read().decode('utf-8')
+        proc.stdout.close()
+        list_values = output_data.splitlines()
+        for value in list_values:
+            value_splitted = re.sub(r'\[|\]|\s', '', value).split(':')
+            if value_splitted[0] in sys_prop:
+                values += value_splitted[1]
+    except Exception:
+        pass
+    return values
+
+
+def _get_macos_uuid():
+    # pylint: disable=broad-except
+    import subprocess
+    sp_dict_values = None
+    try:
+        proc = subprocess.Popen(
+            ['/usr/sbin/system_profiler', 'SPHardwareDataType', '-detaillevel', 'full', '-xml'],
+            stdout=subprocess.PIPE)
+        output_data = proc.stdout.read().decode('utf-8')
+        proc.stdout.close()
+        if output_data:
+            sp_dict_values = _parse_osx_xml_plist_data(output_data)
+    except Exception as exc:
+        debug('Failed to fetch OSX/IOS system profile {}'.format(exc))
+    if sp_dict_values:
+        if 'UUID' in sp_dict_values.keys():
+            return sp_dict_values['UUID']
+        if 'serialnumber' in sp_dict_values.keys():
+            return sp_dict_values['serialnumber']
+    return None
+
+
+def _parse_osx_xml_plist_data(data):
+    import plistlib
+    import re
+    dict_values = {}
+    try:  # Python 2
+        xml_data = plistlib.readPlistFromString(data)
+    except AttributeError:  # Python => 3.4
+        # pylint: disable=no-member
+        xml_data = plistlib.loads(data)
+
+    items_dict = xml_data[0]['_items'][0]
+    r = re.compile(r'.*UUID.*')  # Find to example "platform_UUID" key
+    uuid_keys = filter(r.match, items_dict.keys())
+    if uuid_keys:
+        dict_values['UUID'] = items_dict[uuid_keys[0]]
+    if not uuid_keys:
+        r = re.compile(r'.*serial.*number.*')  # Find to example "serial_number" key
+        serialnumber_keys = filter(r.match, items_dict.keys())
+        if serialnumber_keys:
+            dict_values['serialnumber'] = items_dict[serialnumber_keys[0]]
+    return dict_values
+
+
+def _get_fake_uuid(with_hostname=True):
+    """
+    Generate a uuid based on various system information
+    """
+    import xbmc
+    import platform
+    list_values = [xbmc.getInfoLabel('System.Memory(total)')]
+    if with_hostname:
+        list_values.append(platform.node())
+    return '_'.join(list_values)

--- a/resources/lib/navigation/library.py
+++ b/resources/lib/navigation/library.py
@@ -140,7 +140,9 @@ class LibraryActionExecutor(object):
 
     def set_autoupdate_device(self, pathitems):  # pylint: disable=unused-argument
         """Set the current device to manage auto-update of the shared-library (MySQL)"""
-        g.SHARED_DB.set_value('auto_update_device_uuid', common.get_device_uuid())
+        random_uuid = common.get_random_uuid()
+        g.LOCAL_DB.set_value('client_uuid', random_uuid)
+        g.SHARED_DB.set_value('auto_update_device_uuid', random_uuid)
         ui.show_notification(common.get_local_string(30209), time=8000)
 
     def check_autoupdate_device(self, pathitems):  # pylint: disable=unused-argument
@@ -149,7 +151,7 @@ class LibraryActionExecutor(object):
         if uuid is None:
             msg = common.get_local_string(30212)
         else:
-            current_device_uuid = common.get_device_uuid()
+            client_uuid = g.LOCAL_DB.get_value('client_uuid')
             msg = common.get_local_string(30210) \
-                if current_device_uuid == uuid else common.get_local_string(30211)
+                if client_uuid == uuid else common.get_local_string(30211)
         ui.show_notification(msg, time=8000)

--- a/resources/lib/services/library_updater.py
+++ b/resources/lib/services/library_updater.py
@@ -103,9 +103,9 @@ def _compute_next_schedule():
             common.debug('Library auto update scheduled is disabled')
             return None
         if g.ADDON.getSettingBool('use_mysql'):
-            current_device_uuid = common.get_device_uuid()
+            client_uuid = g.LOCAL_DB.get_value('client_uuid')
             uuid = g.SHARED_DB.get_value('auto_update_device_uuid')
-            if current_device_uuid != uuid:
+            if client_uuid != uuid:
                 common.debug('The auto update has been disabled because another device '
                              'has been set as the main update manager')
                 return None


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [X] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
It is no longer possible to use MAC-address to make safe the credentials
due to security-related changes in operating systems in first place android 9 and up
So change keys to use a per device UUID


<s>Side note for macos:
in _get_macos_uuid
the os.popen should be replaced with subprocess
however, first we need to find a user that have an apple products to run the tests
</s>
### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
