### PR TITLE
Improve LibraryUpdateService: wait for settings to be written

### DIFF
--- a/resources/lib/services/library_updater.py
+++ b/resources/lib/services/library_updater.py
@@ -62,6 +62,9 @@ class LibraryUpdateService(xbmc.Monitor):
         As settings changed, we will compute next schedule again
         to ensure it's still correct
         """
+        # wait for slow system (like Raspberry Pi) to write the settings
+        xbmc.sleep(500)
+        # then compute the next schedule
         self.next_schedule = _compute_next_schedule()
 
     def onScanStarted(self, library):


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [X] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [X] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [X] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [X] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [X] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
Slow systems may not have finish to write the settings before we call g.ADDON.getSettingInt('auto_update')

Deleying the call to `_compute_next_schedule() ` in `onSettingsChanged` for 500ms is enough to ensure the settings are updated.