### PR TITLE
Fixed cache identifier again

### DIFF
--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -99,10 +99,10 @@ def _get_identifier(fixed_identifier, identify_from_kwarg_name,
         identifier = fixed_identifier
     else:
         identifier = kwargs.get(identify_from_kwarg_name)
-        if identifier and identify_append_from_kwarg_name and kwargs.get(identify_append_from_kwarg_name):
-            identifier = identifier + '_' + kwargs.get(identify_append_from_kwarg_name)
         if not identifier and args:
             identifier = args[identify_fallback_arg_index]
+        if identifier and identify_append_from_kwarg_name and kwargs.get(identify_append_from_kwarg_name):
+            identifier += '_' + kwargs.get(identify_append_from_kwarg_name)
     # common.debug('Get_identifier identifier value: {}'.format(identifier if identifier else 'None'))
     return identifier
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Didn't queue in the identifier the kwarg value of the page numbering,  so at the page change always loaded from the cache the same elements of the list

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
