### PR TITLE
Fixed mixed languages of infolabels in cache

### DIFF
--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -11,6 +11,11 @@ import resources.lib.common as common
 import resources.lib.kodi.library as library
 from resources.lib.globals import g
 
+try:  # Python 2
+    unicode
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=redefined-builtin
+
 QUALITIES = [
     {'codec': 'h264', 'width': '960', 'height': '540'},
     {'codec': 'h264', 'width': '1920', 'height': '1080'},
@@ -27,14 +32,15 @@ def add_info(videoid, list_item, item, raw_data, set_info=False):
     """Add infolabels to the list_item. The passed in list_item is modified
     in place and the infolabels are returned."""
     # pylint: disable=too-many-locals
+    cache_identifier = unicode(videoid) + '_' + g.LOCAL_DB.get_profile_config('language', '')
     try:
-        cache_entry = g.CACHE.get(cache.CACHE_INFOLABELS, videoid)
+        cache_entry = g.CACHE.get(cache.CACHE_INFOLABELS, cache_identifier)
         infos = cache_entry['infos']
         quality_infos = cache_entry['quality_infos']
     except cache.CacheMiss:
         infos, quality_infos = parse_info(videoid, item, raw_data)
         # Use a copy of dict to not reflect future changes to the dictionary also to the cache
-        g.CACHE.add(cache.CACHE_INFOLABELS, videoid,
+        g.CACHE.add(cache.CACHE_INFOLABELS, cache_identifier,
                     {'infos': infos.copy(), 'quality_infos': quality_infos},
                     ttl=g.CACHE_METADATA_TTL, to_disk=True)
     if videoid.mediatype == common.VideoId.EPISODE or \


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
When there are multiple profiles in different languages
the plot and titles and other infos are mixed in different profiles language

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
