### PR TITLE
Do not sync on non-owner profile

### DIFF
--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -130,6 +130,11 @@ def _sync_library(videoid, operation):
         'add': 'export_silent',
         'remove': 'remove_silent'}.get(operation)
     if operation and g.ADDON.getSettingBool('mylist_library_sync'):
+        # This is a temporary workaround to prevent export from mylist of non owner account profiles
+        # TODO: in the future you can also add the possibility to synchronize from a chosen profile
+        is_account_owner = g.LOCAL_DB.get_profile_config('isAccountOwner', False)
+        if not is_account_owner:
+            return
         common.debug('Syncing library due to change of my list')
         # We need to wait a little before syncing the library to prevent race
         # conditions with the Container refresh


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Report here what i wrote in an issue post:
initially the addon allowed synchronization only from the main profile.

following recent changes by netflix a bug was introduced in the addon to perform synchronization from any profile by switching profile.

but this however it may seem nice, but in realty caused a bigger problem with auto-synchronization and other api request for wrong permissions to get/post data from netflix.

that's why now I put the warning message forcing the use of the main profile to ensure the correct operation of the auto-sync.

---

to be able to integrate the possibility of choosing the profile to run the auto-sync there are many changes to do, like:
-Do a custom window to get a profile selection in settings
-Find a best solution to perform switch profile so as not to interfere while browsing through the UI (take into account authURL)
-Other changes

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
