### PR TITLE
Allow disabling sort order on my list

### DIFF
--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -135,7 +135,8 @@ def video_list_sorted(context_name, context_id=None, perpetual_range_start=None,
         response_type = 'stdlist_wid'
 
     # enum order: AZ|ZA|Suggested|Year
-    sort_order_types = ['az', 'za', 'su', 'yr']
+    # sort order the "mylist" is supported only in US country, the only way to query is use 'az'
+    sort_order_types = ['az', 'za', 'su', 'yr'] if not context_name == 'mylist' else ['az', 'az']
     req_sort_order_type = sort_order_types[
         int(g.ADDON.getSettingInt('_'.join(('menu_sortorder', menu_data['path'][1]))))]
     base_path.append(req_sort_order_type)

--- a/resources/lib/kodi/listings.py
+++ b/resources/lib/kodi/listings.py
@@ -275,10 +275,11 @@ def build_video_listing(video_list, menu_data, pathitems=None, genre_id=None):
                                 True))
     add_items_previous_next_page(directory_items, pathitems,
                                  video_list.perpetual_range_selector, genre_id)
-    # At the moment it is not possible to make a query with results sorted for the 'mylist',
-    # so we adding the sort order of kodi
     sort_type = 'sort_nothing'
-    if menu_data['path'][1] == 'myList':
+    if menu_data['path'][1] == 'myList' and \
+        int(g.ADDON.getSettingInt('menu_sortorder_mylist')) == 0:
+        # At the moment it is not possible to make a query with results sorted for the 'mylist',
+        # so we adding the sort order of kodi
         sort_type = 'sort_label_ignore_folders'
     parent_menu_data = g.LOCAL_DB.get_value(menu_data['path'][1],
                                             table=TABLE_MENU_DATA, data_type=dict)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -43,7 +43,7 @@
   </category>
   <category label="30166"><!--Main menu items-->
     <setting id="show_menu_mylist" type="bool" label="30167" default="true"/>
-    <setting id="menu_sortorder_mylist" type="select" label="30149" lvalues="30150|30151|30152|30153" visible="false" subsetting="true" default="0"/> <!-- is currently (05-05-2019) no longer supported by the netflix server-->
+    <setting id="menu_sortorder_mylist" type="select" label="30149" lvalues="30150|13106" visible="eq(-1,true)" subsetting="true" default="0"/> <!-- sort order is supported only to US country-->
     <setting id="show_menu_continuewatching" type="bool" label="30168" default="true"/>
     <setting id="show_menu_chosenforyou" type="bool" label="30169" default="true"/>
     <setting id="show_menu_recentlyadded" type="bool" label="30145" default="true"/>


### PR DESCRIPTION
Allows you to keep the chosen order of my list also in the addon. This
feature is currently only allowed in the US country.

### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Only US residents have the ability to manually order my list.
With this PR allow to disable the ordering of Kodi to keep the chosen order.

The query made to get the mylist data with the sort order coded 'az', does not return a list ordered as A-Z, but is assumed to be 'SU' (as "suggested") in non-U.S. countries, while as "Manual ordering" in U.S. countries.

The thing is a bit twisted...and it is for this reason that in the past i set the sorting of Kodi to have the possibility to have the my list sorted alphabetically

Issue ref. https://github.com/CastagnaIT/plugin.video.netflix/issues/295
### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
