### PR TITLE
ESN generation fix

### DIFF
--- a/resources/lib/api/website.py
+++ b/resources/lib/api/website.py
@@ -224,10 +224,13 @@ def generate_esn(user_data):
                 ['/system/bin/getprop', 'ro.nrdp.modelgroup']).strip(' \t\n\r')
 
             esn = ('NFANDROID2-PRV-' if has_product_characteristics_tv else 'NFANDROID1-PRV-')
-            if not nrdp_modelgroup:
-                esn += 'T-L3-'
+            if has_product_characteristics_tv:
+                if nrdp_modelgroup:
+                    esn += nrdp_modelgroup + '-'
+                else:
+                    esn += model.replace(' ', '').upper() + '-'
             else:
-                esn += nrdp_modelgroup + '-'
+                esn += 'T-L3-'
             esn += '{:=<5.5}'.format(manufacturer.upper())
             esn += model.replace(' ', '=').upper()
             esn = sub(r'[^A-Za-z0-9=-]', '=', esn)


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
In the Nvidia shield with Android Pie no more exists ro.nrdp.modelgroup,
so the esn generated became wrong.
(so before Pie: ro.nrdp.modelgroup = SHIELDANDROIDTV)

NFANDROID2-PRV-**SHIELDANDROIDTV**-NVIDISHIELD=ANDROID=TV

instead of it can be used the ro.product.model without spaces,
but this may not be suitable with all L1 devices,
for the moment this is the best solution

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
