### PR TITLE
Parental control fix - load maturity levels dynamically

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -955,23 +955,3 @@ msgstr "Möchten Sie jetzt auf Aktualisierungen prüfen?"
 msgctxt "#30232"
 msgid "Restrict by Maturity Level"
 msgstr ""
-
-msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
-msgid "Content for {} will require the PIN to start playback."
-msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -957,29 +957,9 @@ msgid "Restrict by Maturity Level"
 msgstr ""
 
 msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
 msgid "Content for {} will require the PIN to start playback."
 msgstr ""
 
-msgctxt "#30238"
-msgid ""
-msgstr ""
-
-msgctxt "#30239"  # This is a temporary transition option
+msgctxt "#30234"
 msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -955,23 +955,3 @@ msgstr "Voulez-vous vérifier les mises à jour maintenant?"
 msgctxt "#30232"
 msgid "Restrict by Maturity Level"
 msgstr ""
-
-msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
-msgid "Content for {} will require the PIN to start playback."
-msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -968,23 +968,3 @@ msgstr ""
 msgctxt "#30232"
 msgid "Restrict by Maturity Level"
 msgstr ""
-
-msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
-msgid "Content for {} will require the PIN to start playback."
-msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -957,21 +957,5 @@ msgid "Restrict by Maturity Level"
 msgstr "Limitazione in base alla fascia d'età"
 
 msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr "Bambini piccoli [T]"
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr "Ragazzi"
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr "Adolescenti [VM14]"
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr "Adulti [VM18]"
-
-msgctxt "#30237"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Per riprodurre i contenuti per {} è necessario il PIN."

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -955,23 +955,3 @@ msgstr "Wil je nu controleren voor een update?"
 msgctxt "#30232"
 msgid "Restrict by Maturity Level"
 msgstr ""
-
-msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
-msgid "Content for {} will require the PIN to start playback."
-msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -955,23 +955,3 @@ msgstr "Czy chcesz teraz sprawdzić aktualizację?"
 msgctxt "#30232"
 msgid "Restrict by Maturity Level"
 msgstr ""
-
-msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
-msgid "Content for {} will require the PIN to start playback."
-msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -955,23 +955,3 @@ msgstr "Deseja verificar por atualizações agora?"
 msgctxt "#30232"
 msgid "Restrict by Maturity Level"
 msgstr ""
-
-msgctxt "#30233"
-msgid "Little Kids [T]"
-msgstr ""
-
-msgctxt "#30234"
-msgid "Older Kids"
-msgstr ""
-
-msgctxt "#30235"
-msgid "Teens [VM14]"
-msgstr ""
-
-msgctxt "#30236"
-msgid "Adults [VM18]"
-msgstr ""
-
-msgctxt "#30237"
-msgid "Content for {} will require the PIN to start playback."
-msgstr ""

--- a/resources/lib/kodi/ui/xmldialogs.py
+++ b/resources/lib/kodi/ui/xmldialogs.py
@@ -17,6 +17,13 @@ ACTION_PLAYER_STOP = 13
 ACTION_NAV_BACK = 92
 ACTION_NOOP = 999
 
+XBFONT_LEFT = 0x00000000
+XBFONT_RIGHT = 0x00000001
+XBFONT_CENTER_X = 0x00000002
+XBFONT_CENTER_Y = 0x00000004
+XBFONT_TRUNCATED = 0x00000008
+XBFONT_JUSTIFY = 0x00000010
+
 OS_MACHINE = machine()
 
 CMD_CLOSE_DIALOG_BY_NOOP = 'AlarmClock(closedialog,Action(noop),{},silent)'
@@ -73,33 +80,22 @@ class Skip(xbmcgui.WindowXMLDialog):
             self.close()
 
 
+# pylint: disable=no-member
 class ParentalControl(xbmcgui.WindowXMLDialog):
     """
     Dialog for parental control settings
     """
     def __init__(self, *args, **kwargs):
-        # Convert slider value to Netflix maturity levels
-        self.nf_maturity_levels = {
-            0: 0,
-            1: 41,
-            2: 80,
-            3: 100,
-            4: 9999
-        }
         self.current_pin = kwargs.get('pin')
-        self.current_maturity_level = kwargs.get('maturity_level', 4)
-        self.maturity_level_desc = {
-            0: g.ADDON.getLocalizedString(30232),
-            1: g.ADDON.getLocalizedString(30233),
-            2: g.ADDON.getLocalizedString(30234),
-            3: g.ADDON.getLocalizedString(30235),
-            4: g.ADDON.getLocalizedString(30236)
-        }
+        self.maturity_levels = kwargs['maturity_levels']
+        self.maturity_names = kwargs['maturity_names']
+        self.current_level = kwargs['current_level']
+        self.levels_count = len(self.maturity_levels)
         self.maturity_level_edge = {
             0: g.ADDON.getLocalizedString(30108),
-            4: g.ADDON.getLocalizedString(30107)
+            self.levels_count - 1: g.ADDON.getLocalizedString(30107)
         }
-        self.status_base_desc = g.ADDON.getLocalizedString(30237)
+        self.status_base_desc = g.ADDON.getLocalizedString(30233)
         self.action_exitkeys_id = [ACTION_PREVIOUS_MENU,
                                    ACTION_PLAYER_STOP,
                                    ACTION_NAV_BACK]
@@ -109,26 +105,27 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
             xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
 
     def onInit(self):
+        self._generate_levels_labels()
         # Set maturity level status description
-        self._update_status_desc(self.current_maturity_level)
+        self._update_status_desc(self.current_level)
         # PIN input
-        edit_control = self.getControl(2)
+        edit_control = self.getControl(10002)
         edit_control.setType(xbmcgui.INPUT_TYPE_NUMBER, g.ADDON.getLocalizedString(30002))
         edit_control.setText(self.current_pin)
         # Maturity level slider
-        slider_control = self.getControl(4)
+        slider_control = self.getControl(10004)
         # setInt(value, min, delta, max)
-        slider_control.setInt(self.current_maturity_level, 0, 1, 4)
+        slider_control.setInt(self.current_level, 0, 1, self.levels_count - 1)
 
     def onClick(self, controlID):
-        if controlID == 28:  # Save and close dialog
-            pin = self.getControl(2).getText()
+        if controlID == 10028:  # Save and close dialog
+            pin = self.getControl(10002).getText()
             # Validate pin length
             if not self._validate_pin(pin):
                 return
             import resources.lib.api.shakti as api
             data = {'pin': pin,
-                    'maturity_level': self.nf_maturity_levels[self.current_maturity_level]}
+                    'maturity_level': self.maturity_levels[self.current_level]['value']}
             # Send changes to the service
             if not api.set_parental_control_data(data).get('success', False):
                 # Only in case of service problem
@@ -139,7 +136,7 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
             from resources.lib.cache import CACHE_METADATA
             g.CACHE.invalidate(True, [CACHE_METADATA])
             self.close()
-        if controlID in [29, 100]:  # Close dialog
+        if controlID in [10029, 100]:  # Close dialog
             self.close()
 
     def onAction(self, action):
@@ -147,30 +144,50 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
             self.close()
             return
         # Bad thing to check for changes in this way, but i have not found any other ways
-        slider_value = self.getControl(4).getInt()
-        if slider_value != self.current_maturity_level:
+        slider_value = self.getControl(10004).getInt()
+        if slider_value != self.current_level:
             self._update_status_desc(slider_value)
 
     def _update_status_desc(self, maturity_level):
-        self.current_maturity_level = \
-            maturity_level if maturity_level else self.getControl(4).getInt()
-        if self.current_maturity_level in self.maturity_level_edge:
-            status_desc = self.maturity_level_edge[self.current_maturity_level]
+        self.current_level = \
+            maturity_level if maturity_level else self.getControl(10004).getInt()
+        if self.current_level == 0 or self.current_level == self.levels_count - 1:
+            status_desc = self.maturity_level_edge[self.current_level]
         else:
-            ml_included = [self.maturity_level_desc[n] for n in
-                           range(self.current_maturity_level + 1, 5)]
+            ml_included = [self.maturity_names[n]['name'] for n in
+                           range(self.current_level, self.levels_count - 1)]
             status_desc = self.status_base_desc.format(', '.join(ml_included))
-        for ml in range(1, 5):
-            ml_label = '[COLOR red]{}[/COLOR]'.format(self.maturity_level_desc[ml]) \
-                if ml in range(self.current_maturity_level + 1, 5) else self.maturity_level_desc[ml]
-            self.getControl(200 + ml).setLabel(ml_label)
-        self.getControl(9).setLabel(status_desc)
+        self.getControl(10009).setLabel(status_desc)
+        # Update labels color
+        for ml in range(0, self.levels_count - 1):
+            maturity_name = self.maturity_names[ml]['name'] + self.maturity_names[ml]['rating']
+            ml_label = '[COLOR red]{}[/COLOR]'.format(maturity_name) \
+                if ml in range(self.current_level, self.levels_count - 1) else maturity_name
+            self.controls[ml].setLabel(ml_label)
 
     def _validate_pin(self, pin_value):
         if len(pin_value or '') != 4:
             show_ok_dialog('PIN', g.ADDON.getLocalizedString(30106))
             return False
         return True
+
+    def _generate_levels_labels(self):
+        """Generate descriptions for the levels dynamically"""
+        # Limit to 1050 px max (to slider end)
+        width = int(1050 / (self.levels_count - 1))
+        height = 100
+        pos_x = 275
+        pos_y = 668
+        self.controls = {}
+        for lev_n in range(0, self.levels_count - 1):
+            current_x = pos_x + (width * lev_n)
+            maturity_name = self.maturity_names[lev_n]['name'] + \
+                self.maturity_names[lev_n]['rating']
+            lbl = xbmcgui.ControlLabel(current_x, pos_y, width, height, maturity_name,
+                                       font='font12',
+                                       alignment=XBFONT_CENTER_X)
+            self.controls.update({lev_n: lbl})
+            self.addControl(lbl)
 
 
 # pylint: disable=no-member

--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -46,8 +46,7 @@ class AddonActionExecutor(object):
             ui.show_modal_dialog(ui.xmldialogs.ParentalControl,
                                  'plugin-video-netflix-ParentalControl.xml',
                                  g.ADDON.getAddonInfo('path'),
-                                 pin=parental_control_data['pin'],
-                                 maturity_level=parental_control_data['maturity_level'])
+                                 **parental_control_data)
         except MissingCredentialsError:
             ui.show_ok_dialog('Netflix', common.get_local_string(30009))
         except WebsiteParsingError as exc:

--- a/resources/lib/services/nfsession/nfsession.py
+++ b/resources/lib/services/nfsession/nfsession.py
@@ -332,16 +332,45 @@ class NetflixSession(object):
                 # Unauthorized for url ...
                 raise MissingCredentialsError
             raise
-        # Parse web page to get the current maturity level
-        # I have not found how to get it through the API
+        # Warning - parental control levels vary by country or region, no fixed values can be used
+        # I have not found how to get it through the API, so parse web page to get all info
+        # Note: The language of descriptions change in base of the language of selected profile
         pin_response = self._get('pin', data={'password': password})
-        # so counts the number of occurrences of the "maturity-input-item included" class
         from re import findall
-        num_items = len(findall(r'<div class="maturity-input-item.*?included.*?<\/div>',
-                                pin_response.decode('utf-8')))
-        if not num_items:
-            raise WebsiteParsingError('Unable to find maturity level div tag')
-        return {'pin': pin, 'maturity_level': num_items - 1}
+        html_ml_points = findall(r'<div class="maturity-input-item\s.*?<\/div>',
+                                 pin_response.decode('utf-8'))
+        maturity_levels = []
+        maturity_names = []
+        current_level = -1
+        for ml_point in html_ml_points:
+            is_included = bool(findall(r'class="maturity-input-item[^"<>]*?included', ml_point))
+            value = findall(r'value="(\d+)"', ml_point)
+            name = findall(r'<span class="maturity-name">([^"]+?)<\/span>', ml_point)
+            rating = findall(r'<li[^<>]+class="pin-rating-item">([^"]+?)<\/li>', ml_point)
+            if not value:
+                raise WebsiteParsingError('Unable to find maturity level value: {}'.format(ml_point))
+            if name:
+                maturity_names.append({
+                    'name': name[0],
+                    'rating': '[CR][' + rating[0] + ']' if rating else ''
+                })
+            maturity_levels.append({
+                'level': len(maturity_levels),
+                'value': value[0],
+                'is_included': is_included
+            })
+            if is_included:
+                current_level += 1
+        if not html_ml_points:
+            raise WebsiteParsingError('Unable to find html maturity level points')
+        if not maturity_levels:
+            raise WebsiteParsingError('Unable to find maturity levels')
+        if not maturity_names:
+            raise WebsiteParsingError('Unable to find maturity names')
+        common.debug('Parsed maturity levels: {}', maturity_levels)
+        common.debug('Parsed maturity names: {}', maturity_names)
+        return {'pin': pin, 'maturity_levels': maturity_levels, 'maturity_names': maturity_names,
+                'current_level': current_level}
 
     @common.addonsignals_return_call
     @common.time_execution(immediate=True)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -134,7 +134,7 @@
     <setting id="enable_timing" type="bool" label="30134" default="false"/>
     <setting id="disable_modal_error_display" type="bool" label="30130" default="false"/>
     <setting id="ssl_verification" type="bool" label="30024" default="true"/>
-    <setting id="watched_status_by_profile" type="bool" label="30239" default="true"/> <!-- This is a temporary transition option -->
+    <setting id="watched_status_by_profile" type="bool" label="30234" default="true"/> <!-- This is a temporary transition option -->
     <setting label="30117" type="lsep"/><!--Cache-->
     <setting id="cache_ttl" type="slider" option="int" range="0,10,525600" label="30084" default="120"/>
     <setting id="cache_metadata_ttl" type="slider" option="int" range="0,1,365" label="30085" default="30"/>

--- a/resources/skins/default/1080i/plugin-video-netflix-ParentalControl.xml
+++ b/resources/skins/default/1080i/plugin-video-netflix-ParentalControl.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol>2</defaultcontrol>
+	<defaultcontrol>10002</defaultcontrol>
 	<controls>
 		<control type="group">
 			<!-- Note: some tags to the controls have been set even if not necessary to ensure compatibility with the custom skins of kodi -->
 			<top>250</top>
-			<centerleft>50%</centerleft>
+			<left>200</left>
 			<width>1520</width>
 			<!-- Screen background -->
 			<control type="image">
@@ -81,16 +81,16 @@
 			</control>
 
 			<!-- Controls -->
-			<control type="group" id="80">
+			<control type="group" id="10080">
 				<left>0</left>
 				<top>0</top>
 				<width>1200</width>
 				<height>500</height>
 				<defaultcontrol>2</defaultcontrol>
 				<visible>true</visible>
-				<onright>90</onright>
+				<onright>10090</onright>
 
-				<control type="label" id="1">
+				<control type="label" id="10001">
 					<description>PIN description</description>
 					<posy>135</posy>
 					<posx>65</posx>
@@ -105,7 +105,7 @@
 					<wrapmultiline>false</wrapmultiline>
 				</control>
 
-				<control type="edit" id="2">
+				<control type="edit" id="10002">
 					<description>4 PIN digits</description>
 					<left>45</left>
 					<top>180</top>
@@ -122,11 +122,11 @@
 					<texturefocus border="40" colordiffuse="red">buttons/dialogbutton-fo.png</texturefocus>
 					<texturenofocus border="40">buttons/dialogbutton-nofo.png</texturenofocus>
 					<pulseonselect>no</pulseonselect>
-					<onup>90</onup>
-					<ondown>4</ondown>
+					<onup>10090</onup>
+					<ondown>10004</ondown>
 				</control>
 
-				<control type="label" id="3">
+				<control type="label" id="10003">
 					<description>Maturity Level description</description>
 					<posy>296</posy>
 					<posx>65</posx>
@@ -140,7 +140,7 @@
 					<font>font14</font>
 					<wrapmultiline>false</wrapmultiline>
 				</control>
-				<control type="slider" id="4">
+				<control type="slider" id="10004">
 					<description>Maturity Level</description>
 					<left>75</left>
 					<top>360</top>
@@ -151,75 +151,15 @@
 					<textureslidernib>buttons/slider-nib.png</textureslidernib>
 					<textureslidernibfocus colordiffuse="red">buttons/slider-nib.png</textureslidernibfocus>
 					<orientation>horizontal</orientation>
-					<onup>2</onup>
-					<ondown>90</ondown>
+					<onup>10002</onup>
+					<ondown>10090</ondown>
 				</control>
 
-				<control type="label" id="201">
-					<description>ML Little Kids</description>
-					<posy>418</posy>
-					<posx>75</posx>
-					<top>418</top>
-					<left>75</left>
-					<width>262</width>
-					<visible>true</visible>
-					<scroll>true</scroll>
-					<label>$ADDON[plugin.video.netflix 30233]</label>
-					<haspath>false</haspath>
-					<font>font12</font>
-					<wrapmultiline>true</wrapmultiline>
-					<align>center</align>
-				</control>
-				<control type="label" id="202">
-					<description>ML Older Kids</description>
-					<posy>418</posy>
-					<posx>337</posx>
-					<top>418</top>
-					<left>337</left>
-					<width>262</width>
-					<visible>true</visible>
-					<scroll>true</scroll>
-					<label>$ADDON[plugin.video.netflix 30234]</label>
-					<haspath>false</haspath>
-					<font>font12</font>
-					<wrapmultiline>true</wrapmultiline>
-					<align>center</align>
-				</control>
-				<control type="label" id="203">
-					<description>ML Teens</description>
-					<posy>418</posy>
-					<posx>600</posx>
-					<top>418</top>
-					<left>600</left>
-					<width>262</width>
-					<visible>true</visible>
-					<scroll>true</scroll>
-					<label>$ADDON[plugin.video.netflix 30235]</label>
-					<haspath>false</haspath>
-					<font>font12</font>
-					<wrapmultiline>true</wrapmultiline>
-					<align>center</align>
-				</control>
-				<control type="label" id="204">
-					<description>ML Adults</description>
-					<posy>418</posy>
-					<posx>863</posx>
-					<top>418</top>
-					<left>863</left>
-					<width>262</width>
-					<visible>true</visible>
-					<scroll>true</scroll>
-					<label>$ADDON[plugin.video.netflix 30236]</label>
-					<haspath>false</haspath>
-					<font>font12</font>
-					<wrapmultiline>true</wrapmultiline>
-					<align>center</align>
-				</control>
-				<control type="label" id="9">
+				<control type="label" id="10009">
 					<description>ML Current status</description>
-					<posy>480</posy>
+					<posy>500</posy>
 					<posx>75</posx>
-					<top>480</top>
+					<top>500</top>
 					<left>75</left>
 					<width>1050</width>
 					<visible>true</visible>
@@ -232,16 +172,16 @@
 				</control>
 			</control>
 			<!-- Window default side buttons -->
-			<control type="grouplist" id="90">
+			<control type="grouplist" id="10090">
 				<left>1210</left>
 				<top>92</top>
 				<orientation>vertical</orientation>
 				<width>300</width>
 				<height>250</height>
 				<itemgap>-10</itemgap>
-				<onleft>80</onleft>
+				<onleft>10080</onleft>
 
-				<control type="button" id="28">
+				<control type="button" id="10028">
 					<description>OK button</description>
 					<width>300</width>
 					<height>100</height>
@@ -256,7 +196,7 @@
 					<aligny>center</aligny>
 					<pulseonselect>no</pulseonselect>
 				</control>
-				<control type="button" id="29">
+				<control type="button" id="10029">
 					<description>Cancel button</description>
 					<width>300</width>
 					<height>100</height>

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -21,6 +21,13 @@ class Control:
         ''' A stub constructor for the xbmcgui Control class '''
 
 
+class ControlLabel:
+    ''' A reimplementation of the xbmcgui ControlLabel class '''
+
+    def __init__(self, x=0, y=0, width=0, height=0, label='', font=None, textColor=None, disabledColor=None, alignment=None, hasPath=False, angle=None):
+        ''' A stub constructor for the xbmcgui ControlLabel class '''
+
+
 class ControlGeneric(Control):
     ''' A reimplementation of the xbmcgui Control methods of all control classes '''
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Levels change by country and region, so it is not possible to make a static list.
To solve this, i perform a complete parse of the data from the web page

Examples:
Country like germany has different number of maturity levels towards italy or poland
and "adult" rating of poland is different from italy "adult" rating

Unfortunately, the descriptions will follow the language of the netflix profile and not that of the UI kodi, not so bad..

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
