### PR TITLE
Fixed cache set/get Property with pickle data on py3 as suggested by romanvm

### DIFF
--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -10,7 +10,6 @@ resources.lib.kodi.ui
 resources.lib.services.nfsession
 """
 from __future__ import absolute_import, division, unicode_literals
-import base64
 import os
 import sys
 from time import time
@@ -58,10 +57,13 @@ class UnknownCacheBucketError(Exception):
 
 # Logic to get the identifier
 # cache_output: called without params, use the first argument value of the function as identifier
-# cache_output: with identify_from_kwarg_name, get value identifier from kwarg name specified, if None value fallback to first function argument value
+# cache_output: with identify_from_kwarg_name, get value identifier from kwarg name specified,
+#               if None value fallback to first function argument value
 
-# identify_append_from_kwarg_name - if specified append the value after the kwarg identify_from_kwarg_name, to creates a more specific identifier
-# identify_fallback_arg_index - to change the default fallback arg index (0), where the identifier get the value from the func arguments
+# identify_append_from_kwarg_name - if specified append the value after the kwarg identify_from
+#                                  _kwarg_name, to creates a more specific identifier
+# identify_fallback_arg_index - to change the default fallback arg index (0), where the identifier
+#                               get the value from the func arguments
 # fixed_identifier - note if specified all other params are ignored
 
 def cache_output(g, bucket, fixed_identifier=None,
@@ -154,6 +156,7 @@ class Cache(object):
         self.metadata_ttl = metadata_ttl
         self.buckets = {}
         self.window = xbmcgui.Window(10000)
+        self.PY_IS_VER2 = sys.version_info.major == 2
 
     def lock_marker(self):
         """Return a lock marker for this instance and the current time"""
@@ -235,39 +238,34 @@ class Cache(object):
         return self.buckets[key]
 
     def _load_bucket(self, bucket):
-        wnd_property = None
         # Try 10 times to acquire a lock
         for _ in range(1, 10):
-            wnd_property_data = base64.b64decode(self.window.getProperty(_window_property(bucket)))
-            if wnd_property_data:
-                try:
-                    wnd_property = pickle.loads(wnd_property_data)
-                except Exception:  # pylint: disable=broad-except
-                    self.common.debug('No instance of {} found. Creating new instance.', bucket)
-            if isinstance(wnd_property, unicode) and wnd_property.startswith('LOCKED'):
+            wnd_property_data = self.window.getProperty(_window_property(bucket))
+            if wnd_property_data.startswith(str('LOCKED_BY_')):
                 self.common.debug('Waiting for release of {}', bucket)
                 xbmc.sleep(50)
             else:
-                return self._load_bucket_from_wndprop(bucket, wnd_property)
+                return self._load_bucket_from_wndprop(bucket, wnd_property_data)
         self.common.warn('{} is locked. Working with an empty instance...', bucket)
         return {}
 
-    def _load_bucket_from_wndprop(self, bucket, wnd_property):
-        if wnd_property is None:
+    def _load_bucket_from_wndprop(self, bucket, wnd_property_data):
+        try:
+            if self.PY_IS_VER2:
+                # pickle.loads on py2 wants string
+                bucket_instance = pickle.loads(wnd_property_data)
+            else:
+                bucket_instance = pickle.loads(wnd_property_data.encode('latin-1'))
+        except Exception:  # pylint: disable=broad-except
+            # When window.getProperty does not have the property here happen an error
+            self.common.debug('No instance of {} found. Creating new instance.'.format(bucket))
             bucket_instance = {}
-        else:
-            bucket_instance = wnd_property
         self._lock(bucket)
         self.common.debug('Acquired lock on {}', bucket)
         return bucket_instance
 
     def _lock(self, bucket):
-        # Note pickle.dumps produces byte not str cannot be passed as is in setProperty (with py3)
-        # because with getProperty cause UnicodeDecodeError due to not decodable characters
-        # an Py2/Py3 compatible way is encode pickle data in to base64 string
-        # requires additional conversion step work but works
-        self.window.setProperty(_window_property(bucket),
-                                base64.b64encode(pickle.dumps(self.lock_marker())).decode('utf-8'))
+        self.window.setProperty(_window_property(bucket), self.lock_marker())
 
     def _get_from_disk(self, bucket, identifier):
         """Load a cache entry from disk and add it to the in memory bucket"""
@@ -276,7 +274,7 @@ class Cache(object):
             raise CacheMiss()
         handle = xbmcvfs.File(cache_filename, 'rb')
         try:
-            if sys.version_info.major == 2:
+            if self.PY_IS_VER2:
                 # pickle.loads on py2 wants string
                 return pickle.loads(handle.read())
             # py3
@@ -289,13 +287,12 @@ class Cache(object):
 
     def _add_to_disk(self, bucket, identifier, cache_entry):
         """Write a cache entry to disk"""
-        # pylint: disable=broad-except
         cache_filename = self._entry_filename(bucket, identifier)
         handle = xbmcvfs.File(cache_filename, 'wb')
         try:
             # return pickle.dump(cache_entry, handle)
             handle.write(bytearray(pickle.dumps(cache_entry)))
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             self.common.error('Failed to write cache entry to {}: {}', cache_filename, exc)
         finally:
             handle.close()
@@ -305,21 +302,23 @@ class Cache(object):
         return xbmc.translatePath(os.path.join(*file_loc))
 
     def _persist_bucket(self, bucket, contents):
-        # pylint: disable=broad-except
         if not self.is_safe_to_persist(bucket):
             self.common.warn(
                 '{} is locked by another instance. Discarding changes'
                 .format(bucket))
             return
-
         try:
-            # Note pickle.dumps produces byte not str cannot be passed as is in setProperty (with py3)
-            # because with getProperty cause UnicodeDecodeError due to not decodable characters
-            # an Py2/Py3 compatible way is encode pickle data in to base64 string
-            # requires additional conversion step work but works
-            self.window.setProperty(_window_property(bucket),
-                                    base64.b64encode(pickle.dumps(contents)).decode('utf-8'))
-        except Exception as exc:
+            if self.PY_IS_VER2 == 2:
+                self.window.setProperty(_window_property(bucket), pickle.dumps(contents))
+            else:
+                # Note: On python 3 pickle.dumps produces byte not str cannot be passed as is in
+                # setProperty because cannot receive arbitrary byte sequences if they contain
+                # null bytes \x00, the stored value will be truncated by this null byte (Kodi bug).
+                # To store pickled data in Python 3, you should use protocol 0 explicitly and decode
+                # the resulted value with latin-1 encoding to str and then pass it to setPropety.
+                self.window.setProperty(_window_property(bucket),
+                                        pickle.dumps(contents, protocol=0).decode('latin-1'))
+        except Exception as exc:  # pylint: disable=broad-except
             self.common.error('Failed to persist {} to wnd properties: {}', bucket, exc)
             self.window.clearProperty(_window_property(bucket))
         finally:
@@ -328,18 +327,20 @@ class Cache(object):
     def is_safe_to_persist(self, bucket):
         # Only persist if we acquired the original lock or if the lock is older
         # than 15 seconds (override stale locks)
-        lock_data = base64.b64decode(self.window.getProperty(_window_property(bucket)))
-        lock = ''
-        if lock_data:
-            lock = pickle.loads(lock_data)
-        is_own_lock = lock[:14] == self.lock_marker()[:14]
-        try:
-            is_stale_lock = int(lock[18:] or 1) <= time() - 15
-        except ValueError:
-            is_stale_lock = False
-        if is_stale_lock:
-            self.common.info('Overriding stale cache lock {} on {}', lock, bucket)
-        return is_own_lock or is_stale_lock
+        lock_data = self.window.getProperty(_window_property(bucket))
+        if lock_data.startswith(str('LOCKED_BY_')):
+            # Eg. LOCKED_BY_0001_AT_1574951301
+            # Check if is same add-on invocation: 'LOCKED_BY_0001'
+            is_own_lock = lock_data[:14] == self.lock_marker()[:14]
+            try:
+                # Check if is time is older then 15 sec (last part after AT_)
+                is_stale_lock = int(lock_data[18:] or 1) <= time() - 15
+            except ValueError:
+                is_stale_lock = False
+            if is_stale_lock:
+                self.common.info('Overriding stale cache lock {} on {}', lock_data, bucket)
+            return is_own_lock or is_stale_lock
+        return True
 
     def verify_ttl(self, bucket, identifier, cache_entry):
         """Verify if cache_entry has reached its EOL.


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
This PR finally fixes the problem of data storage/reading on python 3 with get/setProperty
Thanks to romanvm for clarifying the situation on the property

Ref:
> Yes, [setProperty](https://github.com/romanvm/Kodistubs/blob/master/xbmcgui.py#L3760) accepts both `str` (bytes) and `unicode` in Python 2. The same is for Python 3: it can accept both `bytes` and `str` (Unicode). But there is a big BUT: in Python 3 it cannot receive arbitrary byte sequences if they contain null bytes `\x00`. The stored value will be truncated by this null byte. This is how conversion from `const char*` to `str` works in Python 3 C API. I haven't found a workaround for this, but I'm not a big expert in Python C API.
> 
> So in Python 3 setProperty should receive only `str` or `bytes` that were encoded from `str` (UTF-8 encoding is strongly recommended) and do not contain null bytes `\x00`. Then the stored value can be obtained by getProperty.
> 
> **UPD**: For example, you can get this null bytes problem when you try to store data pickled by a binary protocol in Python 3. If you need to store pickled data in Python 3, you should use protocol 0 explicitly and decode the resulted value with `latin-1` encoding to `str` and then pass it to setPropety.


### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
