### PR TITLE
Stream continuity - Recognition of streams between episodes (only for Kodi 19)

### DIFF
--- a/resources/lib/common/misc_utils.py
+++ b/resources/lib/common/misc_utils.py
@@ -236,6 +236,15 @@ def merge_dicts(dict_to_merge, merged_dict):
     return merged_dict
 
 
+def compare_dicts(dict_a, dict_b, excluded_keys=None):
+    """
+    Compare two dict with same keys, with optional keys to exclude from compare
+    """
+    if excluded_keys is None:
+        excluded_keys = []
+    return all(dict_a[k] == dict_b[k] for k in dict_a if k not in excluded_keys)
+
+
 def any_value_except(mapping, excluded_keys):
     """Return a random value from a dict that is not associated with
     excluded_key. Raises StopIteration if there are no other keys than

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -119,6 +119,12 @@ class PlaybackController(xbmc.Monitor):
         except IOError:
             return {}
 
+        # Sometime may happen that when you stop playback, a player status without data is read,
+        # so all dict values are returned with a default empty value,
+        # then return an empty status instead of fake data
+        if not player_state['audiostreams']:
+            return {}
+
         # convert time dict to elapsed seconds
         player_state['elapsed_seconds'] = (
             player_state['time']['hours'] * 3600 +


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
After adding properties in the audio streams and subtitles in the json-rpc call
https://github.com/xbmc/xbmc/pull/16976
https://github.com/xbmc/xbmc/pull/17002

now you can finally implement the changes to solve the problem of incorrect selection of audio/subtutile languages between tvshow episodes

This also fix other errors:
- issue that resetting of the settings saved at db, caused by false data returned by player_status
- double db saving of settings caused by the delay by the Kodi player to perform the restored data
- in some cases incorrect management of the workaround used for forced subtitles, which could be applied even if the subtitle setting on Kodi settings wasn't actually on 'Forced only'

_NOTE: i have done a few tests, but there's too many use cases, at the moment i do not have a tester available, possible problems will be solved when users report_

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
