### PR TITLE
Allow to distinguish dolby atmos streams (Only Kodi 19)

### DIFF
--- a/resources/lib/services/msl/converter.py
+++ b/resources/lib/services/msl/converter.py
@@ -181,6 +181,10 @@ def _convert_audio_track(audio_track, period, init_length, default, drm_streams)
         impaired=impaired,
         original=original,
         default=default)
+    if audio_track['profile'].startswith('ddplus-atmos'):
+        # Append 'ATMOS' description to the dolby atmos streams,
+        # allows users to distinguish the atmos tracks in the audio stream dialog
+        adaptation_set.set('name', 'ATMOS')
     for downloadable in audio_track['streams']:
         # Some audio stream has no drm
         # if downloadable['isDrm'] != drm_streams:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Due to the lack of a parameter in Kodi it has never been possible to add custom descriptions in the streams

Pending approval of https://github.com/xbmc/xbmc/pull/17032
Users will finally be able to distinguish the ATMOS tracks in the Kodi audio stream dialog

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
![image](https://user-images.githubusercontent.com/3257156/70731939-e5775100-1d07-11ea-8d28-1232e02a8cd1.png)
