### PR TITLE
Versionfix for alpa and beta strings

### DIFF
--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -197,7 +197,7 @@ class GlobalVariables(object):
         self.ADDON = xbmcaddon.Addon()
         self.ADDON_ID = self.ADDON.getAddonInfo('id')
         self.PLUGIN = self.ADDON.getAddonInfo('name')
-        self.VERSION = self.ADDON.getAddonInfo('version')
+        self.VERSION = self.ADDON.getAddonInfo('version').split('~',1)[0]
         self.DEFAULT_FANART = self.ADDON.getAddonInfo('fanart')
         self.ICON = self.ADDON.getAddonInfo('icon')
         self.ADDON_DATA_PATH = self.ADDON.getAddonInfo('path')  # Addon folder

--- a/resources/lib/upgrade_controller.py
+++ b/resources/lib/upgrade_controller.py
@@ -17,7 +17,7 @@ from resources.lib.database.db_update import run_local_db_updates, run_shared_db
 def check_addon_upgrade():
     """Check addon upgrade and perform necessary update operations"""
     # Upgrades that require user interaction or to be performed outside of the service
-    addon_previous_ver = g.LOCAL_DB.get_value('addon_previous_version', None)
+    addon_previous_ver = g.LOCAL_DB.get_value('addon_previous_version', None).split('~',1)[0]
     addon_current_ver = g.VERSION
     if addon_current_ver != addon_previous_ver:
         _perform_addon_changes(addon_previous_ver, addon_current_ver)
@@ -32,7 +32,7 @@ def check_service_upgrade():
     _perform_local_db_changes(local_db_version)
     _perform_shared_db_changes(shared_db_version)
     # Perform service changes
-    service_previous_ver = g.LOCAL_DB.get_value('service_previous_version', None)
+    service_previous_ver = g.LOCAL_DB.get_value('service_previous_version', None).split('~',1)[0]
     service_current_ver = g.VERSION
     if service_current_ver != service_previous_ver:
         _perform_service_changes(service_previous_ver, service_current_ver)


### PR DESCRIPTION
Hi,

since a while i'm using your addon version and for using before your public release via repo i build my own zip with beta version string like in kodi addon doc is defined:

https://kodi.wiki/view/Addon.xml

`1.1.2.1 How versioning works

    2.2.9 is newer than 2.2.1
    2.2.10 is newer than 2.2.1
    2.3.0 is newer than 2.2.9
    2.2.1 is newer than 2.2.1~alpha
    2.2.1 is newer than 2.2.1~beta
    2.2.1~beta is newer than 2.2.1~alpha
    2.2.1~beta3 is newer than 2.2.1~beta2
    2.2.1~beta10 is newer than 2.2.1~beta1`

Based on this syntax i change my addons version string - for example:

Your last publiched version:
1.16.0

My version string based on your 1.16.0 with latest commits:
1.16.1~beta12062149 (date and time coded)

This version string will break your check - to solve i included a simple string split based on '~' as delimator and only using first array which will fix the python fail by non int values.

Would be nice if you can merge it to solve issues with addon version strings based on official syntax.
