### PR TITLE
Video progress and watched status with Netflix services

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@
 
 ## Disclaimer
 
-This plugin is not officially commisioned/supported by Netflix.
+This plugin is not officially commissioned/supported by Netflix.
 The trademark "Netflix" is registered by "Netflix, Inc."
 
 ## Features
 
 - Access to multiple profiles
 - Search Netflix including suggestions
-- Netflix categories, recommendations, My List & continue watching and more
+- Netflix categories, recommendations, My List, continue watching and more
 - Browse all movies and all TV shows Netflix style includes genres
 - Browse trailers & more of TV shows and movies (by context menu)
-- Rate TV show & movies
+- Can synchronize the watched status with Netflix service - [How works and limitations](https://github.com/CastagnaIT/plugin.video.netflix/wiki/Sync-watched-status-with-Netflix)
+- Rate TV shows and movies
 - Add or remove to/from My List
 - Export of TV shows & movies in Kodi local library
 - Keep Netflix My List and Kodi local library in sync
@@ -134,9 +135,10 @@ set: `Preferred subtitle language` to `Forced only`
 The Kodi 18.x framework does not allow to fix this problem. So there is no solution.<br/>
 If you prefer you can disable `Remember audio / subtitle preferences` in the addon Playback settings, so in each video you will manually enable the subtitles.
 
-### My watched status is not being updated on website or apps
+### I have some problem with the synchronisation of watched status
 
-The addon does not report watched status back to Netflix (yet).
+Before asking for help, please read the WiKi may already provide an answer:
+[Synchronisation of watched status with Netflix](https://github.com/CastagnaIT/plugin.video.netflix/wiki/Sync-watched-status-with-Netflix)
 
 ### How to export to Kodi library
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -964,6 +964,6 @@ msgctxt "#30234"
 msgid "Install Up Next add-on"
 msgstr ""
 
-msgctxt "#30500"
+msgctxt "#30235"
 msgid "[WIP] Send/Receive progress and watched status of the videos (works only with the main profile)"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -967,3 +967,11 @@ msgstr ""
 msgctxt "#30235"
 msgid "[WIP] Send/Receive progress and watched status of the videos (works only with the main profile)"
 msgstr ""
+
+msgctxt "#30236"
+msgid "Change watched status (locally)"
+msgstr ""
+
+msgctxt "#30237"
+msgid "Marked as watched|Marked as unwatched|Restored Netflix watched status"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -963,3 +963,7 @@ msgstr ""
 msgctxt "#30234"
 msgid "Install Up Next add-on"
 msgstr ""
+
+msgctxt "#30500"
+msgid "[WIP] Send/Receive progress and watched status of the videos (works only with the main profile)"
+msgstr ""

--- a/resources/lib/api/paths.py
+++ b/resources/lib/api/paths.py
@@ -39,7 +39,7 @@ ART_PARTIAL_PATHS = [
 ]
 
 VIDEO_LIST_PARTIAL_PATHS = [
-    [['summary', 'title', 'synopsis', 'regularSynopsis', 'evidence', 'queue',
+    [['requestId', 'summary', 'title', 'synopsis', 'regularSynopsis', 'evidence', 'queue',
       'episodeCount', 'info', 'maturity', 'runtime', 'seasonCount',
       'releaseYear', 'userRating', 'numSeasonsLabel', 'bookmarkPosition',
       'dpSupplementalMessage', 'watched', 'delivery']],
@@ -64,9 +64,9 @@ SEASONS_PARTIAL_PATHS = [
 ] + ART_PARTIAL_PATHS
 
 EPISODES_PARTIAL_PATHS = [
-    [['summary', 'synopsis', 'title', 'runtime', 'releaseYear', 'queue',
+    [['requestId', 'summary', 'synopsis', 'title', 'runtime', 'releaseYear', 'queue',
       'info', 'maturity', 'userRating', 'bookmarkPosition', 'creditsOffset',
-      'watched', 'delivery']],
+      'watched', 'delivery', 'trackIds']],
     [['genres', 'tags', 'creators', 'directors', 'cast'],
      {'from': 0, 'to': 10}, ['id', 'name']]
 ] + ART_PARTIAL_PATHS

--- a/resources/lib/api/paths.py
+++ b/resources/lib/api/paths.py
@@ -41,7 +41,7 @@ ART_PARTIAL_PATHS = [
 VIDEO_LIST_PARTIAL_PATHS = [
     [['requestId', 'summary', 'title', 'synopsis', 'regularSynopsis', 'evidence', 'queue',
       'episodeCount', 'info', 'maturity', 'runtime', 'seasonCount',
-      'releaseYear', 'userRating', 'numSeasonsLabel', 'bookmarkPosition',
+      'releaseYear', 'userRating', 'numSeasonsLabel', 'bookmarkPosition', 'creditsOffset'
       'dpSupplementalMessage', 'watched', 'delivery']],
     [['genres', 'tags', 'creators', 'directors', 'cast'],
      {'from': 0, 'to': 10}, ['id', 'name']]
@@ -72,7 +72,8 @@ EPISODES_PARTIAL_PATHS = [
 ] + ART_PARTIAL_PATHS
 
 TRAILER_PARTIAL_PATHS = [
-    [['availability', 'summary', 'synopsis', 'title', 'trackId', 'delivery', 'runtime']]
+    [['availability', 'summary', 'synopsis', 'title', 'trackId', 'delivery', 'runtime',
+      'bookmarkPosition', 'creditsOffset']]
 ] + ART_PARTIAL_PATHS
 
 EVENT_PATHS = [

--- a/resources/lib/api/paths.py
+++ b/resources/lib/api/paths.py
@@ -75,6 +75,10 @@ TRAILER_PARTIAL_PATHS = [
     [['availability', 'summary', 'synopsis', 'title', 'trackId', 'delivery', 'runtime']]
 ] + ART_PARTIAL_PATHS
 
+EVENT_PATHS = [
+    [['requestId', 'title', 'runtime', 'queue', 'bookmarkPosition', 'watched', 'trackIds']]
+]
+
 VIDEO_LIST_RATING_THUMB_PATHS = [
     [['summary', 'title', 'userRating', 'trackIds']]
 ]

--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -21,7 +21,7 @@ from .data_types import (LoLoMo, VideoList, VideoListSorted, SeasonList, Episode
 from .paths import (VIDEO_LIST_PARTIAL_PATHS, VIDEO_LIST_BASIC_PARTIAL_PATHS,
                     SEASONS_PARTIAL_PATHS, EPISODES_PARTIAL_PATHS, ART_PARTIAL_PATHS,
                     GENRE_PARTIAL_PATHS, RANGE_SELECTOR, MAX_PATH_REQUEST_SIZE,
-                    TRAILER_PARTIAL_PATHS)
+                    TRAILER_PARTIAL_PATHS, EVENT_PATHS)
 from .exceptions import (InvalidVideoListTypeError, APIError, MissingCredentialsError,
                          MetadataNotAvailable)
 from .website import parse_profiles
@@ -266,6 +266,18 @@ def single_info(videoid):
     if videoid.mediatype == common.VideoId.EPISODE:
         paths.extend(build_paths(['videos', videoid.tvshowid],
                                  ART_PARTIAL_PATHS + [['title']]))
+    return common.make_call('path_request', paths)
+
+
+@common.time_execution(immediate=False)
+def event_info(videoid):
+    """Retrieve info for the events"""
+    if videoid.mediatype not in [common.VideoId.EPISODE, common.VideoId.MOVIE,
+                                 common.VideoId.SUPPLEMENTAL]:
+        raise common.InvalidVideoId('Cannot request event info for {}'
+                                    .format(videoid))
+    common.debug('Requesting event info for {}', videoid)
+    paths = build_paths(['videos', videoid.value], EVENT_PATHS)
     return common.make_call('path_request', paths)
 
 

--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -115,7 +115,7 @@ def list_id_for_type(list_type):
 
 
 @common.time_execution(immediate=False)
-@cache.cache_output(cache.CACHE_COMMON, identify_from_kwarg_name='list_id')
+@cache.cache_output(cache.CACHE_COMMON, identify_from_kwarg_name='list_id', save_call_data=True)
 def video_list(list_id, perpetual_range_start=None):
     """Retrieve a single video list
     some of this type of request seems to have results fixed at ~40 from netflix
@@ -134,7 +134,7 @@ def video_list(list_id, perpetual_range_start=None):
 
 @common.time_execution(immediate=False)
 @cache.cache_output(cache.CACHE_COMMON, identify_from_kwarg_name='context_id',
-                    identify_append_from_kwarg_name='perpetual_range_start')
+                    identify_append_from_kwarg_name='perpetual_range_start', save_call_data=True)
 def video_list_sorted(context_name, context_id=None, perpetual_range_start=None, menu_data=None):
     """Retrieve a single video list sorted
     this type of request allows to obtain more than ~40 results
@@ -218,7 +218,7 @@ def seasons(videoid):
 
 @common.time_execution(immediate=False)
 @cache.cache_output(cache.CACHE_COMMON, identify_from_kwarg_name='videoid_value',
-                    identify_append_from_kwarg_name='perpetual_range_start')
+                    identify_append_from_kwarg_name='perpetual_range_start', save_call_data=True)
 def episodes(videoid, videoid_value, perpetual_range_start=None):  # pylint: disable=unused-argument
     """Retrieve episodes of a season"""
     if videoid.mediatype != common.VideoId.SEASON:
@@ -239,7 +239,7 @@ def episodes(videoid, videoid_value, perpetual_range_start=None):  # pylint: dis
 
 
 @common.time_execution(immediate=False)
-@cache.cache_output(cache.CACHE_SUPPLEMENTAL)
+@cache.cache_output(cache.CACHE_SUPPLEMENTAL, save_call_data=True)
 def supplemental_video_list(videoid, supplemental_type):
     """Retrieve a supplemental video list"""
     if videoid.mediatype != common.VideoId.SHOW and videoid.mediatype != common.VideoId.MOVIE:

--- a/resources/lib/api/website.py
+++ b/resources/lib/api/website.py
@@ -87,6 +87,7 @@ def extract_session_data(content, validate=False):
     # Save api urls
     for key, path in list(api_data.items()):
         g.LOCAL_DB.set_value(key, path, TABLE_SESSION)
+    return api_data
 
 
 @common.time_execution(immediate=True)

--- a/resources/lib/api/website.py
+++ b/resources/lib/api/website.py
@@ -46,7 +46,8 @@ PAGE_ITEMS_API_URL = {
     'auth_url': 'models/userInfo/data/authURL',
     # 'ichnaea_log': 'models/serverDefs/data/ICHNAEA_ROOT',  can be for XSS attacks?
     'api_endpoint_root_url': 'models/serverDefs/data/API_ROOT',
-    'api_endpoint_url': 'models/playerModel/data/config/ui/initParams/apiUrl'
+    'api_endpoint_url': 'models/playerModel/data/config/ui/initParams/apiUrl',
+    'request_id': 'models/serverDefs/data/requestId'
 }
 
 PAGE_ITEM_ERROR_CODE = 'models/flow/data/fields/errorCode/value'

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -28,6 +28,7 @@ import xbmcgui
 import xbmcvfs
 
 from resources.lib import common
+from resources.lib.database.db_utils import TABLE_SESSION
 from resources.lib.globals import g
 
 try:
@@ -81,7 +82,8 @@ def cache_output(bucket, fixed_identifier=None,
                  identify_append_from_kwarg_name=None,
                  identify_fallback_arg_index=0,
                  ttl=None,
-                 to_disk=False):
+                 to_disk=False,
+                 save_call_data=False):
     """Decorator that ensures caching the output of a function"""
     # pylint: disable=missing-docstring, invalid-name, too-many-arguments
     def caching_decorator(func):
@@ -94,6 +96,10 @@ def cache_output(bucket, fixed_identifier=None,
                                              identify_fallback_arg_index,
                                              args,
                                              kwargs)
+                if save_call_data and not g.IS_SKIN_CALL:
+                    g.LOCAL_DB.set_value('cache_last_directory_call',
+                                         {'bucket': bucket, 'identifier': identifier, 'to_disk': to_disk},
+                                         table=TABLE_SESSION)
                 if not identifier:
                     # Do not cache if identifier couldn't be determined
                     return func(*args, **kwargs)

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -195,6 +195,15 @@ class Cache(object):
         if to_disk:
             self._add_to_disk(bucket, identifier, cache_entry)
 
+    def update(self, bucket, identifier, content, to_disk=False):
+        """Update an item content to a cache bucket"""
+        cache_entry = self._get_bucket(bucket).get(identifier)
+        if cache_entry is None:
+            raise CacheMiss()
+        cache_entry['content'] = content
+        if to_disk:
+            self._add_to_disk(bucket, identifier, cache_entry)
+
     def commit(self):
         """Persist cache contents in window properties"""
         for bucket in list(self.buckets.keys()):

--- a/resources/lib/common/ipc.py
+++ b/resources/lib/common/ipc.py
@@ -32,6 +32,7 @@ class Signals(object):  # pylint: disable=no-init
     # pylint: disable=too-few-public-methods
     PLAYBACK_INITIATED = 'playback_initiated'
     ESN_CHANGED = 'esn_changed'
+    RELEASE_LICENSE = 'release_license'
     LIBRARY_UPDATE_REQUESTED = 'library_update_requested'
     UPNEXT_ADDON_INIT = 'upnext_data'
     INVALIDATE_SERVICE_CACHE = 'invalidate_service_cache'

--- a/resources/lib/common/ipc.py
+++ b/resources/lib/common/ipc.py
@@ -35,6 +35,7 @@ class Signals(object):  # pylint: disable=no-init
     LIBRARY_UPDATE_REQUESTED = 'library_update_requested'
     UPNEXT_ADDON_INIT = 'upnext_data'
     INVALIDATE_SERVICE_CACHE = 'invalidate_service_cache'
+    QUEUE_VIDEO_EVENT = 'queue_video_event'
 
 
 def register_slot(callback, signal=None, source_id=None):

--- a/resources/lib/common/kodiops.py
+++ b/resources/lib/common/kodiops.py
@@ -50,7 +50,7 @@ def json_rpc(method, params=None):
     request_data = {'jsonrpc': '2.0', 'method': method, 'id': 1,
                     'params': params or {}}
     request = json.dumps(request_data)
-    debug('Executing JSON-RPC: {}'.format(request))
+    debug('Executing JSON-RPC: {}', request)
     raw_response = xbmc.executeJSONRPC(request)
     # debug('JSON-RPC response: {}'.format(raw_response))
     response = json.loads(raw_response)
@@ -59,6 +59,26 @@ def json_rpc(method, params=None):
                       .format(response['error']['code'],
                               response['error']['message']))
     return response['result']
+
+
+def json_rpc_multi(method, list_params=None):
+    """
+    Executes multiple JSON-RPC with the same method in Kodi
+
+    :param method: The JSON-RPC method to call
+    :type method: string
+    :param list_params: Multiple list of parameters of the method call
+    :type list_params: a list of dict
+    :returns: dict -- Method call result
+    """
+    request_data = [{'jsonrpc': '2.0', 'method': method, 'id': 1,
+                    'params': params or {}} for params in list_params]
+    request = json.dumps(request_data)
+    debug('Executing JSON-RPC: {}', request)
+    raw_response = xbmc.executeJSONRPC(request)
+    if 'error' in raw_response:
+        raise IOError('JSONRPC-Error {}'.format(raw_response))
+    return json.loads(raw_response)
 
 
 def update_library_item_details(dbtype, dbid, details):

--- a/resources/lib/common/kodiops.py
+++ b/resources/lib/common/kodiops.py
@@ -204,6 +204,7 @@ def _adjust_locale(locale_code, lang_code_without_country_exists):
     Locale conversion helper
     Conversion table to prevent Kodi to display
     es-ES as Spanish - Spanish, pt-BR as Portuguese - Breton, and so on
+    Kodi issue: https://github.com/xbmc/xbmc/issues/15308
     """
     locale_conversion_table = {
         'es-ES': 'es-Spain',

--- a/resources/lib/common/kodiops.py
+++ b/resources/lib/common/kodiops.py
@@ -154,9 +154,7 @@ def get_kodi_audio_language():
     Return the audio language from Kodi settings
     """
     audio_language = json_rpc('Settings.GetSettingValue', {'setting': 'locale.audiolanguage'})
-    audio_language = xbmc.convertLanguage(g.py2_encode(audio_language['value']), xbmc.ISO_639_1)
-    audio_language = audio_language if audio_language else xbmc.getLanguage(xbmc.ISO_639_1, False)
-    return audio_language if audio_language else 'en'
+    return convert_language_iso(audio_language['value'])
 
 
 def get_kodi_subtitle_language():
@@ -166,12 +164,20 @@ def get_kodi_subtitle_language():
     subtitle_language = json_rpc('Settings.GetSettingValue', {'setting': 'locale.subtitlelanguage'})
     if subtitle_language['value'] == 'forced_only':
         return subtitle_language['value']
-    subtitle_language = xbmc.convertLanguage(g.py2_encode(subtitle_language['value']),
-                                             xbmc.ISO_639_1)
-    subtitle_language = subtitle_language if subtitle_language else xbmc.getLanguage(xbmc.ISO_639_1,
-                                                                                     False)
-    subtitle_language = subtitle_language if subtitle_language else 'en'
-    return subtitle_language
+    return convert_language_iso(subtitle_language['value'])
+
+
+def convert_language_iso(from_value, use_fallback=True):
+    """
+    Convert language code from an English name or three letter code (ISO 639-2) to two letter code (ISO 639-1)
+
+    :param use_fallback: if True when the conversion fails, is returned the current Kodi active language
+    """
+    converted_lang = xbmc.convertLanguage(g.py2_encode(from_value), xbmc.ISO_639_1)
+    if not use_fallback:
+        return converted_lang
+    converted_lang = converted_lang if converted_lang else xbmc.getLanguage(xbmc.ISO_639_1, False)
+    return converted_lang if converted_lang else 'en'
 
 
 def fix_locale_languages(data_list):

--- a/resources/lib/common/kodiops.py
+++ b/resources/lib/common/kodiops.py
@@ -71,8 +71,7 @@ def json_rpc_multi(method, list_params=None):
     :type list_params: a list of dict
     :returns: dict -- Method call result
     """
-    request_data = [{'jsonrpc': '2.0', 'method': method, 'id': 1,
-                    'params': params or {}} for params in list_params]
+    request_data = [{'jsonrpc': '2.0', 'method': method, 'id': 1, 'params': params or {}} for params in list_params]
     request = json.dumps(request_data)
     debug('Executing JSON-RPC: {}', request)
     raw_response = xbmc.executeJSONRPC(request)

--- a/resources/lib/common/misc_utils.py
+++ b/resources/lib/common/misc_utils.py
@@ -261,6 +261,10 @@ def any_value_except(mapping, excluded_keys):
     return next(mapping[key] for key in mapping if key not in excluded_keys)
 
 
+def enclose_quotes(content):
+    return '"' + content + '"'
+
+
 def time_execution(immediate):
     """A decorator that wraps a function call and times its execution"""
     # pylint: disable=missing-docstring

--- a/resources/lib/database/db_create_mysql.py
+++ b/resources/lib/database/db_create_mysql.py
@@ -95,5 +95,17 @@ def create_database(config):
     cur.execute(table)
     cur.execute(alter_tbl)
 
+    table = ('CREATE TABLE netflix_addon.watched_status_override ('
+             'ProfileGuid VARCHAR(50) NOT NULL,'
+             'VideoID INT(11) NOT NULL,'
+             'Value TEXT DEFAULT NULL,'
+             'PRIMARY KEY (ProfileGuid, VideoID))'
+             'ENGINE = INNODB, CHARACTER SET utf8mb4, COLLATE utf8mb4_unicode_ci;')
+    alter_tbl = ('ALTER TABLE netflix_addon.watched_status_override '
+                 'ADD CONSTRAINT FK_watchedstatusoverride_ProfileGuid FOREIGN KEY (ProfileGuid)'
+                 'REFERENCES netflix_addon.profiles(Guid) ON DELETE CASCADE ON UPDATE CASCADE;')
+    cur.execute(table)
+    cur.execute(alter_tbl)
+
     if conn and conn.is_connected():
         conn.close()

--- a/resources/lib/database/db_create_sqlite.py
+++ b/resources/lib/database/db_create_sqlite.py
@@ -121,5 +121,14 @@ def _create_shared_database(db_file_path):
                 'NfoExport     TEXT    NOT NULL DEFAULT (\'False\'));')
     cur.execute(table)
 
+    table = str('CREATE TABLE watched_status_override ('
+                'ProfileGuid      TEXT    NOT NULL,'
+                'VideoID          INTEGER NOT NULL,'
+                'Value            TEXT,'
+                'PRIMARY KEY (ProfileGuid, VideoID ),'
+                'FOREIGN KEY (ProfileGuid)'
+                'REFERENCES Profiles (Guid) ON DELETE CASCADE ON UPDATE CASCADE);')
+    cur.execute(table)
+
     if conn:
         conn.close()

--- a/resources/lib/database/db_update.py
+++ b/resources/lib/database/db_update.py
@@ -13,21 +13,62 @@ import resources.lib.common as common
 from resources.lib.globals import g
 
 
-def run_local_db_updates(db_version, db_new_version):
+def run_local_db_updates(db_version, db_new_version):  # pylint: disable=unused-argument
     """Perform database actions for a db version change"""
     # The changes must be left in sequence to allow cascade operations on non-updated databases
     if common.is_less_version(db_version, '0.2'):
         pass
     if common.is_less_version(db_version, '0.3'):
         pass
-    g.LOCAL_DB.set_value('db_version', db_new_version)
 
 
-def run_shared_db_updates(db_version, db_new_version):
+def run_shared_db_updates(db_version, db_new_version):  # pylint: disable=unused-argument
     """Perform database actions for a db version change"""
     # The changes must be left in sequence to allow cascade operations on non-updated databases
+
     if common.is_less_version(db_version, '0.2'):
-        pass
+        # Changes: added table 'watched_status_override'
+
+        # SQLite
+        import sqlite3 as sql
+        from resources.lib.database.db_base_sqlite import CONN_ISOLATION_LEVEL
+        from resources.lib.database import db_utils
+
+        shared_db_conn = sql.connect(db_utils.get_local_db_path(db_utils.SHARED_DB_FILENAME),
+                                     isolation_level=CONN_ISOLATION_LEVEL)
+        cur = shared_db_conn.cursor()
+
+        table = str('CREATE TABLE watched_status_override ('
+                    'ProfileGuid      TEXT    NOT NULL,'
+                    'VideoID          INTEGER NOT NULL,'
+                    'Value            TEXT,'
+                    'PRIMARY KEY (ProfileGuid, VideoID ),'
+                    'FOREIGN KEY (ProfileGuid)'
+                    'REFERENCES Profiles (Guid) ON DELETE CASCADE ON UPDATE CASCADE);')
+        cur.execute(table)
+        shared_db_conn.close()
+
+        # MySQL
+        if g.ADDON.getSettingBool('use_mysql'):
+            import mysql.connector
+            from resources.lib.database.db_base_mysql import MySQLDatabase
+
+            shared_db_conn = MySQLDatabase()
+            shared_db_conn.conn = mysql.connector.connect(**shared_db_conn.config)
+            cur = shared_db_conn.conn.cursor()
+
+            table = ('CREATE TABLE netflix_addon.watched_status_override ('
+                     'ProfileGuid VARCHAR(50) NOT NULL,'
+                     'VideoID INT(11) NOT NULL,'
+                     'Value TEXT DEFAULT NULL,'
+                     'PRIMARY KEY (ProfileGuid, VideoID))'
+                     'ENGINE = INNODB, CHARACTER SET utf8mb4, COLLATE utf8mb4_unicode_ci;')
+            alter_tbl = ('ALTER TABLE netflix_addon.watched_status_override '
+                         'ADD CONSTRAINT FK_watchedstatusoverride_ProfileGuid FOREIGN KEY (ProfileGuid)'
+                         'REFERENCES netflix_addon.profiles(Guid) ON DELETE CASCADE ON UPDATE CASCADE;')
+            cur.execute(table)
+            cur.execute(alter_tbl)
+            shared_db_conn.conn.close()
+
     if common.is_less_version(db_version, '0.3'):
         pass
-    g.LOCAL_DB.set_value('db_version', db_new_version)

--- a/resources/lib/database/db_update.py
+++ b/resources/lib/database/db_update.py
@@ -13,20 +13,20 @@ import resources.lib.common as common
 from resources.lib.globals import g
 
 
-def run_local_db_updates(db_version, db_new_version):  # pylint: disable=unused-argument
+def run_local_db_updates(current_version, upgrade_to_version):  # pylint: disable=unused-argument
     """Perform database actions for a db version change"""
     # The changes must be left in sequence to allow cascade operations on non-updated databases
-    if common.is_less_version(db_version, '0.2'):
+    if common.is_less_version(current_version, '0.2'):
         pass
-    if common.is_less_version(db_version, '0.3'):
+    if common.is_less_version(current_version, '0.3'):
         pass
 
 
-def run_shared_db_updates(db_version, db_new_version):  # pylint: disable=unused-argument
+def run_shared_db_updates(current_version, upgrade_to_version):  # pylint: disable=unused-argument
     """Perform database actions for a db version change"""
     # The changes must be left in sequence to allow cascade operations on non-updated databases
 
-    if common.is_less_version(db_version, '0.2'):
+    if common.is_less_version(current_version, '0.2'):
         # Changes: added table 'watched_status_override'
 
         # SQLite
@@ -70,5 +70,5 @@ def run_shared_db_updates(db_version, db_new_version):  # pylint: disable=unused
             cur.execute(alter_tbl)
             shared_db_conn.conn.close()
 
-    if common.is_less_version(db_version, '0.3'):
+    if common.is_less_version(current_version, '0.3'):
         pass

--- a/resources/lib/kodi/context_menu.py
+++ b/resources/lib/kodi/context_menu.py
@@ -61,7 +61,10 @@ CONTEXT_MENU_ACTIONS = {
         'url': ctx_item_url(['trailer'])},
     'force_update_mylist': {
         'label': common.get_local_string(30214),
-        'url': ctx_item_url(['force_update_mylist'])}
+        'url': ctx_item_url(['force_update_mylist'])},
+    'change_watched_status': {
+        'label': common.get_local_string(30236),
+        'url': ctx_item_url(['change_watched_status'])}
 }
 
 
@@ -96,6 +99,11 @@ def generate_context_menu_items(videoid):
                        if videoid in api.mylist_items()
                        else 'add_to_list')
         items.insert(0, _ctx_item(list_action, videoid))
+
+    if videoid.mediatype in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
+        # Add menu to allow change manually the watched status when progress manager is enabled
+        if g.ADDON.getSettingBool('ProgressManager_enabled') and g.LOCAL_DB.get_profile_config('isAccountOwner', False):
+            items.insert(0, _ctx_item('change_watched_status', videoid))
 
     return items
 

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -64,6 +64,8 @@ def add_info(videoid, list_item, item, raw_data, handle_highlighted_title=False)
        videoid.mediatype == common.VideoId.SUPPLEMENTAL:
         list_item.setProperty('isFolder', 'false')
         list_item.setProperty('IsPlayable', 'true')
+        # Set the resume and watched status to the list item
+        _set_progress_status(list_item, item, infos_copy)
     else:
         list_item.setProperty('isFolder', 'true')
     for stream_type, quality_infos in iteritems(quality_infos):
@@ -345,3 +347,35 @@ def _colorize_title(text, color, remove_color=False):
         if not matches:
             return '[COLOR {}]{}[/COLOR]'.format(color, text)
     return text
+
+
+def _set_progress_status(list_item, video_data, infos):
+    """Check and set progress status (watched and resume)"""
+    if not g.ADDON.getSettingBool('ProgressManager_enabled') or \
+            not g.LOCAL_DB.get_profile_config('isAccountOwner', False):
+        # Currently due to a unknown problem, it is not possible to communicate MSL data to the right selected
+        # profile other than the owner profile
+        return
+    # Todo: implement a way to let user change manually the watched status (values saved on db)
+    #  then check from db if user has manually changed the watched status
+
+    # NOTE shakti 'watched' tag value:
+    # in my tests playing a video (via web browser) until to the end this value is not changed to True
+    # seem not respect really if a video is watched to the end or this tag have other purposes
+    # to now, the only way to know if a video is watched is compare the bookmarkPosition with creditsOffset value
+
+    if not video_data.get('creditsOffset'):
+        # NOTE shakti 'creditsOffset' tag not exists on video type 'movie',
+        # then simulate the default Kodi playcount behaviour (playcountminimumpercent)
+        watched_threshold = video_data['runtime'] - (video_data['runtime'] / 100 * 90)
+    else:
+        watched_threshold = video_data['creditsOffset']
+
+    # NOTE shakti 'bookmarkPosition' tag when it is not set have -1 value
+    playcount = '1' if video_data['bookmarkPosition'] >= watched_threshold else '0'
+    if playcount == '0' and video_data['bookmarkPosition'] > 0:
+        list_item.setProperty('ResumeTime', str(video_data['bookmarkPosition']))
+        list_item.setProperty('TotalTime', str(video_data['runtime']))
+    # We have to set playcount with setInfo(), because the setProperty('PlayCount', ) have a bug
+    # when a item is already watched and you force to set again watched, the override do not work
+    infos['PlayCount'] = playcount

--- a/resources/lib/kodi/listings.py
+++ b/resources/lib/kodi/listings.py
@@ -390,9 +390,7 @@ def _create_supplemental_item(videoid_value, video, video_list, params):
     url = common.build_url(videoid=videoid,
                            mode=g.MODE_PLAY,
                            params=params)
-    # replaceItems still look broken because it does not remove the default ctx menu
-    # i hope in the future Kodi fix this
-    list_item.addContextMenuItems(generate_context_menu_items(videoid), replaceItems=True)
+    list_item.addContextMenuItems(generate_context_menu_items(videoid))
     return (url, list_item, False)
 
 

--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -154,7 +154,7 @@ class AddonActionExecutor(object):
         # Open root page
         xbmc.executebuiltin('Container.Update({},replace)'.format(url))  # replace=reset history
 
-    def change_watched_status(self, pathitems=None):
+    def change_watched_status(self, pathitems=None):  # pylint: disable=unused-argument
         from os import path
         videoid = path.basename(path.normpath(xbmc.getInfoLabel('ListItem.Path')))
         if videoid.isdigit():

--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -11,12 +11,11 @@ from __future__ import absolute_import, division, unicode_literals
 
 import xbmc
 
-from resources.lib.globals import g
-import resources.lib.common as common
 import resources.lib.api.shakti as api
+import resources.lib.common as common
 import resources.lib.kodi.ui as ui
-
-from resources.lib.api.exceptions import (MissingCredentialsError, WebsiteParsingError)
+from resources.lib.api.exceptions import MissingCredentialsError, WebsiteParsingError
+from resources.lib.globals import g
 
 
 class AddonActionExecutor(object):
@@ -154,6 +153,28 @@ class AddonActionExecutor(object):
         url = 'plugin://plugin.video.netflix'
         # Open root page
         xbmc.executebuiltin('Container.Update({},replace)'.format(url))  # replace=reset history
+
+    def change_watched_status(self, pathitems=None):
+        from os import path
+        videoid = path.basename(path.normpath(xbmc.getInfoLabel('ListItem.Path')))
+        if videoid.isdigit():
+            # Todo: how get resumetime/playcount of selected item for calculate current watched status?
+
+            profile_guid = g.LOCAL_DB.get_active_profile_guid()
+            current_value = g.SHARED_DB.get_watched_status(profile_guid, videoid, None, bool)
+            if current_value:
+                txt_index = 1
+                g.SHARED_DB.set_watched_status(profile_guid, videoid, False)
+            elif current_value is not None and not current_value:
+                txt_index = 2
+                g.SHARED_DB.delete_watched_status(profile_guid, videoid)
+            else:
+                txt_index = 0
+                g.SHARED_DB.set_watched_status(profile_guid, videoid, True)
+            ui.show_notification(common.get_local_string(30237).split('|')[txt_index])
+            common.refresh_container()
+        else:
+            common.error('No video id found in the current path: {}', path)
 
 
 def _sync_library(videoid, operation):

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -169,15 +169,14 @@ def _verify_pin(pin_required):
 
 def _get_event_data(videoid):
     """Get data needed to send event requests to Netflix and for resume from last position"""
-    api_data = api.single_info(videoid)
+    api_data = api.event_info(videoid)
     if not api_data:
         return {}
-    # Todo: request via api only data needed
     videoid_data = api_data['videos'][videoid.value]
     common.debug('Event data: {}', videoid_data)
 
-    event_data = {'resume_position': videoid_data['bookmarkPosition']
-                  if videoid_data['bookmarkPosition'] > -1 else None,
+    event_data = {'resume_position':
+                  videoid_data['bookmarkPosition'] if videoid_data['bookmarkPosition'] > -1 else None,
                   'runtime': videoid_data['runtime'],
                   'request_id': videoid_data['requestId'],
                   'watched': videoid_data['watched'],

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -16,7 +16,7 @@ from xbmcgui import Window
 from resources.lib.globals import g
 from resources.lib.common import (info, debug, warn, error, check_credentials, BackendNotReady,
                                   log_time_trace, reset_log_level_global_var,
-                                  get_current_kodi_profile_name)
+                                  get_current_kodi_profile_name, update_cache_videoid_runtime)
 from resources.lib.upgrade_controller import check_addon_upgrade
 
 
@@ -148,6 +148,7 @@ def run(argv):
     success = True
 
     window_cls = Window(10000)  # Kodi home window
+
     # If you use multiple Kodi profiles you need to distinguish the property of current profile
     prop_nf_service_status = g.py2_encode('nf_service_status_' + get_current_kodi_profile_name())
     is_widget_skin_call = _skin_widget_call(window_cls, prop_nf_service_status)
@@ -164,6 +165,8 @@ def run(argv):
                 if g.IS_ADDON_FIRSTRUN:
                     check_addon_upgrade()
                 g.initial_addon_configuration()
+                if not is_widget_skin_call:
+                    update_cache_videoid_runtime(window_cls)
                 route([part for part in g.PATH.split('/') if part])
             else:
                 success = False

--- a/resources/lib/run_service.py
+++ b/resources/lib/run_service.py
@@ -115,8 +115,8 @@ class NetflixService(object):
 
     def _tick_and_wait_for_abort(self):
         try:
-            self.controller.on_playback_tick()
-            self.library_updater.on_tick()
+            self.controller.on_service_tick()
+            self.library_updater.on_service_tick()
         except Exception as exc:  # pylint: disable=broad-except
             import traceback
             from resources.lib.kodi.ui import show_notification

--- a/resources/lib/services/library_updater.py
+++ b/resources/lib/services/library_updater.py
@@ -45,7 +45,7 @@ class LibraryUpdateService(xbmc.Monitor):
             g.ADDON.getAddonInfo('id'), common.Signals.LIBRARY_UPDATE_REQUESTED,
             self.update_kodi_library)
 
-    def on_tick(self):
+    def on_service_tick(self):
         """Check if update is due and trigger it"""
         if not self.enabled:
             return

--- a/resources/lib/services/msl/event_tag_builder.py
+++ b/resources/lib/services/msl/event_tag_builder.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2017 Sebastian Golasch (plugin.video.netflix)
+    Copyright (C) 2019 Stefano Gottardo - @CastagnaIT (original implementation module)
+    Build event tags values
+
+    SPDX-License-Identifier: MIT
+    See LICENSES/MIT.md for more information.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+
+def get_media_id(videoid, player_state, manifest):
+    """Try to build the mediaId by parsing manifest with the current player streams used"""
+    # Build using 'new_track_id' tags
+    # Format example: "A:1:1;2;en;1;|V:2:1;2;;default;1;CE3;0;|T:1:1;1;NONE;0;1;"
+    return manifest['defaultTrackOrderList'][0]['mediaId']  # Todo: test purpose
+
+
+def get_play_times(videoid, player_state, manifest):
+    """Build the playTimes dict by parsing manifest with the current player streams used"""
+    duration = player_state['elapsed_seconds'] * 1000
+
+    # Todo: elaborate from manifest
+    audio_downloadable_id = manifest['audio_tracks'][0]['streams'][0]['downloadable_id']  # Todo: test purpose
+    video_downloadable_id = manifest['video_tracks'][0]['streams'][0]['downloadable_id']  # Todo: test purpose
+
+    play_times = {
+        'total': duration,
+        'audio': [{
+            'downloadableId': audio_downloadable_id,
+            'duration': duration
+        }],
+        'video': [{
+            'downloadableId': video_downloadable_id,
+            'duration': duration
+        }],
+        'text': []
+    }
+    return play_times

--- a/resources/lib/services/msl/event_tag_builder.py
+++ b/resources/lib/services/msl/event_tag_builder.py
@@ -9,21 +9,43 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 
+from resources.lib import common
 
-def get_media_id(videoid, player_state, manifest):
-    """Try to build the mediaId by parsing manifest with the current player streams used"""
-    # Build using 'new_track_id' tags
-    # Format example: "A:1:1;2;en;1;|V:2:1;2;;default;1;CE3;0;|T:1:1;1;NONE;0;1;"
-    return manifest['defaultTrackOrderList'][0]['mediaId']  # Todo: test purpose
+AUDIO_CHANNELS_CONV = {1: '1.0', 2: '2.0', 6: '5.1', 8: '7.1'}
 
 
-def get_play_times(videoid, player_state, manifest):
-    """Build the playTimes dict by parsing manifest with the current player streams used"""
+def is_media_changed(previous_player_state, player_state):
+    """Check if there are variations in player state to avoids overhead processing"""
+    if not previous_player_state:
+        return True
+    # To now we do not check subtitle, because to the moment it is not implemented
+    if player_state['currentvideostream'] != previous_player_state['currentvideostream'] or \
+            player_state['currentaudiostream'] != previous_player_state['currentaudiostream']:
+        return True
+    return False
+
+
+def update_play_times_duration(play_times, player_state):
+    """Update the playTimes duration values"""
+    duration = player_state['elapsed_seconds'] * 1000
+    play_times['total'] = duration
+    play_times['audio'][0]['duration'] = duration
+    play_times['video'][0]['duration'] = duration
+
+
+def build_media_tag(player_state, manifest):
+    """Build the playTimes and the mediaId data by parsing manifest and the current player streams used"""
+    common.fix_locale_languages(manifest['audio_tracks'])
     duration = player_state['elapsed_seconds'] * 1000
 
-    # Todo: elaborate from manifest
-    audio_downloadable_id = manifest['audio_tracks'][0]['streams'][0]['downloadable_id']  # Todo: test purpose
-    video_downloadable_id = manifest['video_tracks'][0]['streams'][0]['downloadable_id']  # Todo: test purpose
+    audio_downloadable_id, audio_track_id = _find_audio_data(player_state, manifest)
+    video_downloadable_id, video_track_id = _find_video_data(player_state, manifest)
+    # Warning 'currentsubtitle' value in player_state on Kodi 18
+    # do not have proprieties like isdefault, isforced, isimpaired
+    # if in the future the implementation will be done it should be available only on Kodi 19
+    # then for now we leave the subtitles as disabled
+
+    text_track_id = 'T:1:1;1;NONE;0;1;'
 
     play_times = {
         'total': duration,
@@ -37,4 +59,41 @@ def get_play_times(videoid, player_state, manifest):
         }],
         'text': []
     }
-    return play_times
+
+    # Format example: "A:1:1;2;en;1;|V:2:1;2;;default;1;CE3;0;|T:1:1;1;NONE;0;1;"
+    media_id = '|'.join([audio_track_id, video_track_id, text_track_id])
+
+    return play_times, media_id
+
+
+def _find_audio_data(player_state, manifest):
+    """
+    Find the audio downloadable id and the audio track id
+    """
+    language = common.convert_language_iso(player_state['currentaudiostream']['language'])
+    channels = AUDIO_CHANNELS_CONV[player_state['currentaudiostream']['channels']]
+
+    for audio_track in manifest['audio_tracks']:
+        if audio_track['language'] == language and audio_track['channels'] == channels:
+            # Get the stream dict with the highest bitrate
+            stream = max(audio_track['streams'], key=lambda x: x['bitrate'])
+            return stream['downloadable_id'], audio_track['new_track_id']
+    # Not found?
+    raise Exception('build_media_tag: unable to find audio data with language: {}, channels: {}'
+                    .format(language, channels))
+
+
+def _find_video_data(player_state, manifest):
+    """
+    Find the best match for the video downloadable id and the video track id
+    """
+    codec = player_state['currentvideostream']['codec']
+    width = player_state['currentvideostream']['width']
+    height = player_state['currentvideostream']['height']
+    for video_track in manifest['video_tracks']:
+        for stream in video_track['streams']:
+            if codec in stream['content_profile'] and width == stream['res_w'] and height == stream['res_h']:
+                return stream['downloadable_id'], video_track['new_track_id']
+    # Not found?
+    raise Exception('build_media_tag: unable to find video data with codec: {}, width: {}, height: {}'
+                    .format(codec, width, height))

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -65,7 +65,7 @@ class Event(object):
         self.status = self.STATUS_SUCCESS
 
     def is_response_success(self):
-        return self.status == self.STATUS_SUCCESS
+        return self.status == self.STATUS_SUCCESS and self.req_attempt <= 3
 
     def is_attempts_granted(self):
         """Returns True if you can make new request attempts"""
@@ -125,8 +125,8 @@ class EventsHandler(threading.Thread):
                 common.error('EVENT [{}] - The request has failed: {}', event, exc)
         if event.event_type == EVENT_STOP:
             self.clear_queue()
-        if event.event_type == EVENT_START and not event.is_response_success():
-            # If 'start' event was unsuccessful,
+        if not event.is_response_success():
+            # The event request is unsuccessful then there is some problem,
             # no longer make any future requests from this event id
             return False
         return True

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2017 Sebastian Golasch (plugin.video.netflix)
+    Copyright (C) 2019 Stefano Gottardo - @CastagnaIT (original implementation module)
+    Handle and build Netflix events
+
+    SPDX-License-Identifier: MIT
+    See LICENSES/MIT.md for more information.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import random
+import threading
+import time
+
+try:  # Python 2
+    from urllib import urlencode
+except ImportError:  # Python 3
+    from urllib.parse import urlencode
+
+import xbmc
+
+import resources.lib.cache as cache
+from resources.lib import common
+from resources.lib.database.db_utils import TABLE_SESSION
+from resources.lib.globals import g
+from resources.lib.services.msl import event_tag_builder
+from resources.lib.services.msl.msl_handler_base import build_request_data, ENDPOINTS
+
+try:
+    import Queue as queue
+except ImportError:  # Python 3
+    import queue
+
+EVENT_START = 'start'      # events/start : Video starts (seem also after a ff/rw)
+EVENT_STOP = 'stop'        # events/stop : Video stops (seem also after a ff/rw)
+EVENT_KEEP_ALIVE = 'keepAlive'  # events/keepAlive : Update progress status
+EVENT_ENGAGE = 'engage'    # events/engage : After user interaction (e.g. before send stop)
+EVENT_BIND = 'bind'        # events/bind : ?
+
+
+class Event(object):
+    """Object representing an event request to be processed"""
+
+    STATUS_REQUESTED = 'REQUESTED'
+    STATUS_INQUEUE = 'IN_QUEUE'
+    STATUS_ERROR = 'ERROR'
+    STATUS_SUCCESS = 'SUCCESS'
+
+    def __init__(self, event_data):
+        self.event_type = event_data['params']['event']
+        common.debug('Event type [{}] added to queue: {}', self.event_type, event_data)
+        self.status = self.STATUS_INQUEUE
+        self.request_data = event_data
+        self.response_data = None
+        self.req_attempt = 0
+
+    def get_event_id(self):
+        return self.request_data['xid']
+
+    def set_response(self, response):
+        self.response_data = response
+        common.debug('Event type [{}] response: {}', self.event_type, response)
+        # Todo check for possible error in response and set right status
+        self.status = self.STATUS_ERROR
+        self.status = self.STATUS_SUCCESS
+
+    def is_response_success(self):
+        return self.status == self.STATUS_SUCCESS
+
+    def is_attempts_granted(self):
+        """Returns True if you can make new request attempts"""
+        self.req_attempt += 1
+        return True if self.req_attempt <= 3 else False
+
+    def __str__(self):
+        return self.event_type
+
+
+class EventsHandler(threading.Thread):
+    """Handle and build Netflix event requests"""
+
+    def __init__(self, chunked_request):
+        super(EventsHandler, self).__init__()
+        self.chunked_request = chunked_request
+        # session_id, app_id are common to all events
+        self.session_id = int(time.time()) * 10000 + random.randint(1, 10001)
+        self.app_id = None
+        self.queue_events = queue.Queue(maxsize=10)
+        self.cache_data_events = {}
+        self.banned_events_ids = []
+        common.register_slot(signal=common.Signals.QUEUE_VIDEO_EVENT, callback=self.callback_event_video_queue)
+
+    def run(self):
+        """Monitor and process the event queue"""
+        common.debug('[Event queue monitor] Thread started')
+        monitor = xbmc.Monitor()
+        while not monitor.abortRequested():
+            try:
+                # Take the first queued item
+                event = self.queue_events.get_nowait()
+                # Process the request
+                continue_queue = self._process_event_request(event)
+                if not continue_queue:
+                    # Ban future requests from this event id
+                    self.banned_events_ids += [event.get_event_id()]
+            except queue.Empty:
+                pass
+            monitor.waitForAbort(0.5)
+
+    def _process_event_request(self, event):
+        """Do the event post request"""
+        event.status = Event.STATUS_REQUESTED
+        # Request attempts can be made up to a maximum of 3 times per event
+        while event.is_attempts_granted():
+            common.info('Perform event request [{}] (attempt {})', event, event.req_attempt)
+            params = {'reqAttempt': event.req_attempt,
+                      'reqPriority': 20 if event.event_type == EVENT_START else 0,
+                      'reqName': 'events/{}'.format(event)}
+            url = ENDPOINTS['events'] + '?' + urlencode(params).replace('%2F', '/')
+            try:
+                response = self.chunked_request(url, event.request_data, g.get_esn())
+                event.set_response(response)
+                break
+            except Exception as exc:
+                common.error('Event request [{}] failed: {}', event, exc)
+        if event.event_type == EVENT_STOP:
+            self.clear_queue()
+        if event.event_type == EVENT_START and not event.is_response_success():
+            # If 'start' event was unsuccessful,
+            # no longer make any future requests from this event id
+            return False
+        return True
+
+    def callback_event_video_queue(self, data=None):
+        """Callback to add a video event"""
+        self.add_event_to_queue(data['event_type'], data['event_data'], data['player_state'])
+
+    def add_event_to_queue(self, event_type, event_data, player_state):
+        """Adds an event in the queue of events to be processed"""
+        videoid = common.VideoId.from_dict(event_data['videoid'])
+        previous_data = self.cache_data_events.get(videoid.value, {})
+        manifest = get_manifest(videoid)
+        url = manifest['links']['events']['href']
+
+        if previous_data.get('xid') in self.banned_events_ids:
+            common.warn('Event [{}] not added, is banned for a previous request event error',
+                        event_type)
+            return
+
+        event_data = build_request_data(url, self._build_event_params(event_type,
+                                                                      event_data,
+                                                                      player_state,
+                                                                      manifest))
+        try:
+            self.queue_events.put_nowait(Event(event_data))
+        except queue.Full:
+            common.warn('Events queue is full, event [{}] not queued', event_type)
+
+    def clear_queue(self):
+        """Clear all queued events"""
+        with self.queue_events.mutex:
+            self.queue_events.queue.clear()
+        self.cache_data_events = {}
+        self.banned_events_ids = []
+
+    def _build_event_params(self, event_type, event_data, player_state, manifest):
+        """Build data params for an event request"""
+        videoid = common.VideoId.from_dict(event_data['videoid'])
+        # Get previous elaborated data of the same video id
+        # Some tags must remain unchanged between events
+        previous_data = self.cache_data_events.get(videoid.value, {})
+        timestamp = int(time.time() * 10000)
+
+        # Context location values can be easily viewed from tag data-ui-tracking-context
+        # of a preview box in website html
+        play_ctx_location = 'WATCHNOW'  # We currently leave a fixed value, we leave support for future changes
+        # play_ctx_location = 'MyListAsGallery' if event_data['is_in_mylist'] else 'browseTitles'
+
+        # To now it is not mandatory, we leave support for future changes
+        # if event_data['is_played_by_library']:
+        #     list_id = 'unknown'
+        # else:
+        #     list_id = g.LOCAL_DB.get_value('last_menu_id', 'unknown')
+
+        params = {
+            'event': event_type,
+            'xid': previous_data.get('xid', str(timestamp + 1610)),
+            'position': player_state['elapsed_seconds'] * 1000,  # Video time elapsed
+            'clientTime': timestamp,
+            'sessionStartTime': previous_data.get('sessionStartTime', timestamp),
+            'mediaId': event_tag_builder.get_media_id(videoid, player_state, manifest),
+            'trackId': str(event_data['track_id']),
+            'sessionId': str(self.session_id),
+            'appId': str(self.app_id or self.session_id),
+            'playTimes': event_tag_builder.get_play_times(videoid, player_state, manifest),
+            'sessionParams': previous_data.get('sessionParams', {
+                'isUIAutoPlay': False,  # Should be set equal to the one in the manifest
+                'supportsPreReleasePin': True,  # Should be set equal to the one in the manifest
+                'supportsWatermark': True,  # Should be set equal to the one in the manifest
+                'preferUnletterboxed': True,  # Should be set equal to the one in the manifest
+                'uiplaycontext': {
+                    # 'list_id': list_id,  # not mandatory
+                    # 'lolomo_id': g.LOCAL_DB.get_value('lolomo_root_id', '', TABLE_SESSION),  # not mandatory
+                    'location': play_ctx_location,
+                    'rank': 0,  # Perhaps this is a reference of cdn rank used in the manifest? (we use always 0)
+                    'request_id': event_data['request_id'],
+                    'row': 0,  # Purpose not known
+                    'track_id': event_data['track_id'],
+                    'video_id': videoid.value
+                }
+            })
+        }
+
+        if event_type == EVENT_ENGAGE:
+            params['action'] = 'User_Interaction'
+
+        self.cache_data_events[videoid.value] = params
+        return params
+
+
+def get_manifest(videoid):
+    """Get the manifest from cache"""
+    cache_identifier = g.get_esn() + '_' + videoid.value
+    return g.CACHE.get(cache.CACHE_MANIFESTS, cache_identifier, False)

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -22,7 +22,6 @@ import xbmc
 
 import resources.lib.cache as cache
 from resources.lib import common
-from resources.lib.database.db_utils import TABLE_SESSION
 from resources.lib.globals import g
 from resources.lib.services.msl import event_tag_builder
 from resources.lib.services.msl.msl_handler_base import build_request_data, ENDPOINTS
@@ -49,20 +48,20 @@ class Event(object):
 
     def __init__(self, event_data):
         self.event_type = event_data['params']['event']
-        common.debug('Event type [{}] added to queue: {}', self.event_type, event_data)
         self.status = self.STATUS_INQUEUE
         self.request_data = event_data
         self.response_data = None
         self.req_attempt = 0
+        common.debug('EVENT [{}] - Added to queue', self.event_type)
 
     def get_event_id(self):
         return self.request_data['xid']
 
     def set_response(self, response):
         self.response_data = response
-        common.debug('Event type [{}] response: {}', self.event_type, response)
-        # Todo check for possible error in response and set right status
-        self.status = self.STATUS_ERROR
+        common.debug('EVENT [{}] - Request response: {}', self.event_type, response)
+        # Seem that malformed requests are ignored without returning errors
+        # self.status = self.STATUS_ERROR
         self.status = self.STATUS_SUCCESS
 
     def is_response_success(self):
@@ -71,7 +70,7 @@ class Event(object):
     def is_attempts_granted(self):
         """Returns True if you can make new request attempts"""
         self.req_attempt += 1
-        return True if self.req_attempt <= 3 else False
+        return bool(self.req_attempt <= 3)
 
     def __str__(self):
         return self.event_type
@@ -106,14 +105,14 @@ class EventsHandler(threading.Thread):
                     self.banned_events_ids += [event.get_event_id()]
             except queue.Empty:
                 pass
-            monitor.waitForAbort(0.5)
+            monitor.waitForAbort(1)
 
     def _process_event_request(self, event):
         """Do the event post request"""
         event.status = Event.STATUS_REQUESTED
         # Request attempts can be made up to a maximum of 3 times per event
         while event.is_attempts_granted():
-            common.info('Perform event request [{}] (attempt {})', event, event.req_attempt)
+            common.info('EVENT [{}] - Executing request (attempt {})', event, event.req_attempt)
             params = {'reqAttempt': event.req_attempt,
                       'reqPriority': 20 if event.event_type == EVENT_START else 0,
                       'reqName': 'events/{}'.format(event)}
@@ -122,8 +121,8 @@ class EventsHandler(threading.Thread):
                 response = self.chunked_request(url, event.request_data, g.get_esn())
                 event.set_response(response)
                 break
-            except Exception as exc:
-                common.error('Event request [{}] failed: {}', event, exc)
+            except Exception as exc:  # pylint: disable=broad-except
+                common.error('EVENT [{}] - The request has failed: {}', event, exc)
         if event.event_type == EVENT_STOP:
             self.clear_queue()
         if event.event_type == EVENT_START and not event.is_response_success():
@@ -134,28 +133,32 @@ class EventsHandler(threading.Thread):
 
     def callback_event_video_queue(self, data=None):
         """Callback to add a video event"""
-        self.add_event_to_queue(data['event_type'], data['event_data'], data['player_state'])
+        try:
+            self.add_event_to_queue(data['event_type'], data['event_data'], data['player_state'])
+        except Exception as exc:  # pylint: disable=broad-except
+            import traceback
+            from resources.lib.kodi.ui import show_addon_error_info
+            common.error(traceback.format_exc())
+            show_addon_error_info(exc)
 
     def add_event_to_queue(self, event_type, event_data, player_state):
         """Adds an event in the queue of events to be processed"""
         videoid = common.VideoId.from_dict(event_data['videoid'])
-        previous_data = self.cache_data_events.get(videoid.value, {})
+        # pylint: disable=unused-variable
+        previous_data, previous_player_state = self.cache_data_events.get(videoid.value, ({}, None))
         manifest = get_manifest(videoid)
         url = manifest['links']['events']['href']
 
         if previous_data.get('xid') in self.banned_events_ids:
-            common.warn('Event [{}] not added, is banned for a previous request event error',
-                        event_type)
+            common.warn('EVENT [{}] - Not added to the queue. The xid {} is banned due to a previous failed request',
+                        event_type, previous_data.get('xid'))
             return
 
-        event_data = build_request_data(url, self._build_event_params(event_type,
-                                                                      event_data,
-                                                                      player_state,
-                                                                      manifest))
+        event_data = build_request_data(url, self._build_event_params(event_type, event_data, player_state, manifest))
         try:
             self.queue_events.put_nowait(Event(event_data))
         except queue.Full:
-            common.warn('Events queue is full, event [{}] not queued', event_type)
+            common.warn('EVENT [{}] - Not added to the queue. The event queue is full.', event_type)
 
     def clear_queue(self):
         """Clear all queued events"""
@@ -169,7 +172,7 @@ class EventsHandler(threading.Thread):
         videoid = common.VideoId.from_dict(event_data['videoid'])
         # Get previous elaborated data of the same video id
         # Some tags must remain unchanged between events
-        previous_data = self.cache_data_events.get(videoid.value, {})
+        previous_data, previous_player_state = self.cache_data_events.get(videoid.value, ({}, None))
         timestamp = int(time.time() * 10000)
 
         # Context location values can be easily viewed from tag data-ui-tracking-context
@@ -183,22 +186,29 @@ class EventsHandler(threading.Thread):
         # else:
         #     list_id = g.LOCAL_DB.get_value('last_menu_id', 'unknown')
 
+        if event_tag_builder.is_media_changed(previous_player_state, player_state):
+            play_times, media_id = event_tag_builder.build_media_tag(player_state, manifest)
+        else:
+            play_times = previous_data['playTimes']
+            event_tag_builder.update_play_times_duration(play_times, player_state)
+            media_id = previous_data['mediaId']
+
         params = {
             'event': event_type,
             'xid': previous_data.get('xid', str(timestamp + 1610)),
             'position': player_state['elapsed_seconds'] * 1000,  # Video time elapsed
             'clientTime': timestamp,
             'sessionStartTime': previous_data.get('sessionStartTime', timestamp),
-            'mediaId': event_tag_builder.get_media_id(videoid, player_state, manifest),
+            'mediaId': media_id,
             'trackId': str(event_data['track_id']),
             'sessionId': str(self.session_id),
             'appId': str(self.app_id or self.session_id),
-            'playTimes': event_tag_builder.get_play_times(videoid, player_state, manifest),
+            'playTimes': play_times,
             'sessionParams': previous_data.get('sessionParams', {
-                'isUIAutoPlay': False,  # Should be set equal to the one in the manifest
-                'supportsPreReleasePin': True,  # Should be set equal to the one in the manifest
-                'supportsWatermark': True,  # Should be set equal to the one in the manifest
-                'preferUnletterboxed': True,  # Should be set equal to the one in the manifest
+                'isUIAutoPlay': False,  # Should be set equal to the manifest request
+                'supportsPreReleasePin': True,  # Should be set equal to the manifest request
+                'supportsWatermark': True,  # Should be set equal to the manifest request
+                'preferUnletterboxed': True,  # Should be set equal to the manifest request
                 'uiplaycontext': {
                     # 'list_id': list_id,  # not mandatory
                     # 'lolomo_id': g.LOCAL_DB.get_value('lolomo_root_id', '', TABLE_SESSION),  # not mandatory
@@ -215,7 +225,7 @@ class EventsHandler(threading.Thread):
         if event_type == EVENT_ENGAGE:
             params['action'] = 'User_Interaction'
 
-        self.cache_data_events[videoid.value] = params
+        self.cache_data_events[videoid.value] = (params, player_state)
         return params
 
 

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -23,6 +23,7 @@ import xbmc
 # import resources.lib.api.shakti as api
 import resources.lib.cache as cache
 from resources.lib import common
+from resources.lib.database.db_utils import TABLE_SESSION
 from resources.lib.globals import g
 from resources.lib.services.msl import event_tag_builder
 from resources.lib.services.msl.msl_handler_base import build_request_data, ENDPOINTS
@@ -200,7 +201,7 @@ class EventsHandler(threading.Thread):
 
         params = {
             'event': event_type,
-            'xid': previous_data.get('xid', str(timestamp + 1610)),
+            'xid': g.LOCAL_DB.get_value('xid', table=TABLE_SESSION),
             'position': player_state['elapsed_seconds'] * 1000,  # Video time elapsed
             'clientTime': timestamp,
             'sessionStartTime': previous_data.get('sessionStartTime', timestamp),

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -32,10 +32,10 @@ try:
 except ImportError:  # Python 3
     import queue
 
-EVENT_START = 'start'      # events/start : Video starts (seem also after a ff/rw)
-EVENT_STOP = 'stop'        # events/stop : Video stops (seem also after a ff/rw)
+EVENT_START = 'start'      # events/start : Video starts
+EVENT_STOP = 'stop'        # events/stop : Video stops
 EVENT_KEEP_ALIVE = 'keepAlive'  # events/keepAlive : Update progress status
-EVENT_ENGAGE = 'engage'    # events/engage : After user interaction (e.g. before send stop)
+EVENT_ENGAGE = 'engage'    # events/engage : After user interaction (before stop, on skip, on pause)
 EVENT_BIND = 'bind'        # events/bind : ?
 
 

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -20,6 +20,7 @@ except ImportError:  # Python 3
 
 import xbmc
 
+# import resources.lib.api.shakti as api
 import resources.lib.cache as cache
 from resources.lib import common
 from resources.lib.globals import g
@@ -71,6 +72,9 @@ class Event(object):
         """Returns True if you can make new request attempts"""
         self.req_attempt += 1
         return bool(self.req_attempt <= 3)
+
+    def get_video_id(self):
+        return self.request_data['params']['sessionParams']['uiplaycontext']['video_id']
 
     def __str__(self):
         return self.event_type
@@ -125,6 +129,7 @@ class EventsHandler(threading.Thread):
                 common.error('EVENT [{}] - The request has failed: {}', event, exc)
         if event.event_type == EVENT_STOP:
             self.clear_queue()
+            # api.update_lolomo_context('continueWatching', video_id=event.get_video_id())
         if not event.is_response_success():
             # The event request is unsuccessful then there is some problem,
             # no longer make any future requests from this event id

--- a/resources/lib/services/msl/msl_handler.py
+++ b/resources/lib/services/msl/msl_handler.py
@@ -161,10 +161,10 @@ class MSLHandler(MSLHandlerBase):
 
         # Get and check mastertoken validity
         mt_validity = self.check_mastertoken_validity()
-        manifest = self._chunked_request(ENDPOINTS['manifest'],
-                                         build_request_data('/manifest', params),
-                                         esn,
-                                         mt_validity)
+        manifest = self.chunked_request(ENDPOINTS['manifest'],
+                                        build_request_data('/manifest', params),
+                                        esn,
+                                        mt_validity)
         if common.is_debug_verbose():
             # Save the manifest to disk as reference
             common.save_file('manifest.json', json.dumps(manifest).encode('utf-8'))
@@ -196,9 +196,9 @@ class MSLHandler(MSLHandlerBase):
 
         url = self.last_license_url
 
-        response = self._chunked_request(ENDPOINTS['license'],
-                                         build_request_data(url, params, 'sessionId'),
-                                         g.get_esn())
+        response = self.chunked_request(ENDPOINTS['license'],
+                                        build_request_data(url, params, 'sessionId'),
+                                        g.get_esn())
         return response[0]['licenseResponseBase64']
 
     @common.time_execution(immediate=True)

--- a/resources/lib/services/msl/msl_handler.py
+++ b/resources/lib/services/msl/msl_handler.py
@@ -17,6 +17,7 @@ import xbmcaddon
 from resources.lib.globals import g
 import resources.lib.common as common
 import resources.lib.cache as cache
+from .events_handler import EventsHandler
 from .msl_handler_base import MSLHandlerBase, ENDPOINTS, display_error_info, build_request_data
 
 from .request_builder import MSLRequestBuilder
@@ -51,6 +52,9 @@ class MSLHandler(MSLHandlerBase):
             # Addon just installed, the service starts but there is no esn
             if g.get_esn():
                 self.check_mastertoken_validity()
+
+            events_handler = EventsHandler(self.chunked_request)
+            events_handler.start()
         except Exception:
             import traceback
             common.error(traceback.format_exc())

--- a/resources/lib/services/msl/msl_handler.py
+++ b/resources/lib/services/msl/msl_handler.py
@@ -9,24 +9,19 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 
-import re
-import zlib
 import json
 import time
-import base64
-from functools import wraps
 import requests
 import xbmcaddon
 
 from resources.lib.globals import g
 import resources.lib.common as common
-import resources.lib.kodi.ui as ui
 import resources.lib.cache as cache
+from .msl_handler_base import MSLHandlerBase, ENDPOINTS, display_error_info
 
 from .request_builder import MSLRequestBuilder
 from .profiles import enabled_profiles
 from .converter import convert_to_dash
-from .exceptions import MSLError
 
 try:  # Python 2
     unicode
@@ -34,30 +29,7 @@ except NameError:  # Python 3
     unicode = str  # pylint: disable=redefined-builtin
 
 
-CHROME_BASE_URL = 'https://www.netflix.com/nq/msl_v1/cadmium/'
-ENDPOINTS = {
-    'manifest': CHROME_BASE_URL + 'pbo_manifests/%5E1.0.0/router',  # "pbo_manifests/^1.0.0/router"
-    'license': CHROME_BASE_URL + 'pbo_licenses/%5E1.0.0/router'
-}
-
-
-def display_error_info(func):
-    """Decorator that catches errors raise by the decorated function,
-    displays an error info dialog in the UI and reraises the error"""
-    # pylint: disable=missing-docstring
-    @wraps(func)
-    def error_catching_wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as exc:
-            ui.show_error_info(common.get_local_string(30028), unicode(exc),
-                               unknown_error=not(unicode(exc)),
-                               netflix_error=isinstance(exc, MSLError))
-            raise
-    return error_catching_wrapper
-
-
-class MSLHandler(object):
+class MSLHandler(MSLHandlerBase):
     """Handles session management and crypto for license and manifest
     requests"""
     last_license_url = ''
@@ -66,6 +38,7 @@ class MSLHandler(object):
     session = requests.session()
 
     def __init__(self):
+        super(MSLHandler, self).__init__()
         # pylint: disable=broad-except
         self.request_builder = None
         try:
@@ -84,49 +57,6 @@ class MSLHandler(object):
         common.register_slot(
             signal=common.Signals.ESN_CHANGED,
             callback=self.perform_key_handshake)
-
-    def check_mastertoken_validity(self):
-        """Return the mastertoken validity and executes a new key handshake when necessary"""
-        if self.request_builder.crypto.mastertoken:
-            time_now = time.time()
-            renewable = self.request_builder.crypto.renewal_window < time_now
-            expired = self.request_builder.crypto.expiration <= time_now
-        else:
-            renewable = False
-            expired = True
-        if expired:
-            if not self.request_builder.crypto.mastertoken:
-                common.debug('Stored MSL data not available, a new key handshake will be performed')
-                self.request_builder = MSLRequestBuilder()
-            else:
-                common.debug('Stored MSL data is expired, a new key handshake will be performed')
-            if self.perform_key_handshake():
-                self.request_builder = MSLRequestBuilder(json.loads(
-                    common.load_file('msl_data.json')))
-            return self.check_mastertoken_validity()
-        return {'renewable': renewable, 'expired': expired}
-
-    @display_error_info
-    @common.time_execution(immediate=True)
-    def perform_key_handshake(self, data=None):
-        """Perform a key handshake and initialize crypto keys"""
-        # pylint: disable=unused-argument
-        esn = data or g.get_esn()
-        if not esn:
-            common.info('Cannot perform key handshake, missing ESN')
-            return False
-
-        common.debug('Performing key handshake. ESN: {}', esn)
-
-        response = _process_json_response(
-            self._post(ENDPOINTS['manifest'],
-                       self.request_builder.handshake_request(esn)))
-        header_data = self.request_builder.decrypt_header_data(response['headerdata'], False)
-        self.request_builder.crypto.parse_key_response(header_data, not common.is_edge_esn(esn))
-        # Reset the user id token
-        self.request_builder.user_id_token = None
-        common.debug('Key handshake successful')
-        return True
 
     @display_error_info
     @common.time_execution(immediate=True)
@@ -288,137 +218,6 @@ class MSLHandler(object):
         self.last_playback_context = manifest['playbackContextId']
         self.last_drm_context = manifest['drmContextId']
         return convert_to_dash(manifest)
-
-    @common.time_execution(immediate=True)
-    def _chunked_request(self, endpoint, request_data, esn, mt_validity=None):
-        """Do a POST request and process the chunked response"""
-        chunked_response = self._process_chunked_response(
-            self._post(endpoint, self.request_builder.msl_request(request_data, esn)),
-            mt_validity['renewable'] if mt_validity else None)
-        return chunked_response['result']
-
-    @common.time_execution(immediate=True)
-    def _post(self, endpoint, request_data):
-        """Execute a post request"""
-        common.debug('Executing POST request to {}', endpoint)
-        start = time.clock()
-        response = self.session.post(endpoint, request_data)
-        common.debug('Request took {}s', time.clock() - start)
-        common.debug('Request returned response with status {}', response.status_code)
-        response.raise_for_status()
-        return response
-
-    # pylint: disable=unused-argument
-    @common.time_execution(immediate=True)
-    def _process_chunked_response(self, response, mt_renewable):
-        """Parse and decrypt an encrypted chunked response. Raise an error
-        if the response is plaintext json"""
-        try:
-            # if the json() does not fail we have an error because
-            # the expected response is a chunked json response
-            return _raise_if_error(response.json())
-        except ValueError:
-            # json() failed so parse and decrypt the chunked response
-            common.debug('Received encrypted chunked response')
-            response = _parse_chunks(response.text)
-            # TODO: sending for the renewal request is not yet implemented
-            # if mt_renewable:
-            #     # Check if mastertoken is renewed
-            #     self.request_builder.crypto.compare_mastertoken(response['header']['mastertoken'])
-
-            header_data = self.request_builder.decrypt_header_data(
-                response['header'].get('headerdata'))
-
-            if 'useridtoken' in header_data:
-                # After the first call, it is possible get the 'user id token' that contains the
-                # user identity to use instead of 'User Authentication Data' with user credentials
-                self.request_builder.user_id_token = header_data['useridtoken']
-            # if 'keyresponsedata' in header_data:
-            #     common.debug('Found key handshake in response data')
-            #     # Update current mastertoken
-            #     self.request_builder.crypto.parse_key_response(header_data, True)
-            decrypted_response = _decrypt_chunks(response['payloads'], self.request_builder.crypto)
-            return _raise_if_error(decrypted_response)
-
-
-@common.time_execution(immediate=True)
-def _process_json_response(response):
-    """Execute a post request and expect a JSON response"""
-    try:
-        return _raise_if_error(response.json())
-    except ValueError:
-        raise MSLError('Expected JSON response, got {}'.format(response.text))
-
-
-def _raise_if_error(decoded_response):
-    raise_error = False
-    # Catch a manifest/chunk error
-    if any(key in decoded_response for key in ['error', 'errordata']):
-        raise_error = True
-    # Catch a license error
-    if 'result' in decoded_response and isinstance(decoded_response.get('result'), list):
-        if 'error' in decoded_response['result'][0]:
-            raise_error = True
-    if raise_error:
-        common.error('Full MSL error information:')
-        common.error(json.dumps(decoded_response))
-        raise MSLError(_get_error_details(decoded_response))
-    return decoded_response
-
-
-def _get_error_details(decoded_response):
-    # Catch a chunk error
-    if 'errordata' in decoded_response:
-        return json.loads(
-            base64.standard_b64decode(
-                decoded_response['errordata']))['errormsg']
-    # Catch a manifest error
-    if 'error' in decoded_response:
-        if decoded_response['error'].get('errorDisplayMessage'):
-            return decoded_response['error']['errorDisplayMessage']
-    # Catch a license error
-    if 'result' in decoded_response and isinstance(decoded_response.get('result'), list):
-        if 'error' in decoded_response['result'][0]:
-            if decoded_response['result'][0]['error'].get('errorDisplayMessage'):
-                return decoded_response['result'][0]['error']['errorDisplayMessage']
-    return 'Unhandled error check log.'
-
-
-@common.time_execution(immediate=True)
-def _parse_chunks(message):
-    header = json.loads(message.split('}}')[0] + '}}')
-    payloads = re.split(',\"signature\":\"[0-9A-Za-z=/+]+\"}',
-                        message.split('}}')[1])
-    payloads = [x + '}' for x in payloads][:-1]
-    return {'header': header, 'payloads': payloads}
-
-
-@common.time_execution(immediate=True)
-def _decrypt_chunks(chunks, crypto):
-    decrypted_payload = ''
-    for chunk in chunks:
-        payloadchunk = json.loads(chunk)
-        payload = payloadchunk.get('payload')
-        decoded_payload = base64.standard_b64decode(payload)
-        encryption_envelope = json.loads(decoded_payload)
-        # Decrypt the text
-        plaintext = crypto.decrypt(
-            base64.standard_b64decode(encryption_envelope['iv']),
-            base64.standard_b64decode(encryption_envelope.get('ciphertext')))
-        # unpad the plaintext
-        plaintext = json.loads(plaintext)
-        data = plaintext.get('data')
-
-        # uncompress data if compressed
-        if plaintext.get('compressionalgo') == 'GZIP':
-            decoded_data = base64.standard_b64decode(data)
-            data = zlib.decompress(decoded_data, 16 + zlib.MAX_WBITS).decode('utf-8')
-        else:
-            data = base64.standard_b64decode(data).decode('utf-8')
-
-        decrypted_payload += data
-
-    return json.loads(decrypted_payload)
 
 
 def has_1080p(manifest):

--- a/resources/lib/services/msl/msl_handler_base.py
+++ b/resources/lib/services/msl/msl_handler_base.py
@@ -33,7 +33,8 @@ except NameError:  # Python 3
 CHROME_BASE_URL = 'https://www.netflix.com/nq/msl_v1/cadmium/'
 ENDPOINTS = {
     'manifest': CHROME_BASE_URL + 'pbo_manifests/%5E1.0.0/router',  # "pbo_manifests/^1.0.0/router"
-    'license': CHROME_BASE_URL + 'pbo_licenses/%5E1.0.0/router'
+    'license': CHROME_BASE_URL + 'pbo_licenses/%5E1.0.0/router',
+    'events': CHROME_BASE_URL + 'pbo_events/%5E1.0.0/router'
 }
 
 

--- a/resources/lib/services/msl/msl_handler_base.py
+++ b/resources/lib/services/msl/msl_handler_base.py
@@ -159,6 +159,22 @@ class MSLHandlerBase(object):
             return _raise_if_error(decrypted_response)
 
 
+def build_request_data(url, params=None, echo=''):
+    """Create a standard request data"""
+    if not params:
+        raise Exception('Cannot build the message without parameters')
+    timestamp = int(time.time() * 10000)
+    request_data = {
+        'version': 2,
+        'url': url,
+        'id': timestamp,
+        'languages': [g.LOCAL_DB.get_value('locale_id')],
+        'params': params,
+        'echo': echo
+    }
+    return request_data
+
+
 @common.time_execution(immediate=True)
 def _process_json_response(response):
     """Execute a post request and expect a JSON response"""

--- a/resources/lib/services/msl/msl_handler_base.py
+++ b/resources/lib/services/msl/msl_handler_base.py
@@ -168,7 +168,7 @@ def build_request_data(url, params=None, echo=''):
         'version': 2,
         'url': url,
         'id': timestamp,
-        'languages': [g.LOCAL_DB.get_value('locale_id')],
+        'languages': [g.LOCAL_DB.get_profile_config('language')],
         'params': params,
         'echo': echo
     }

--- a/resources/lib/services/msl/msl_handler_base.py
+++ b/resources/lib/services/msl/msl_handler_base.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2017 Sebastian Golasch (plugin.video.netflix)
+    Copyright (C) 2017 Trummerjo (original implementation module)
+    Proxy service to convert manifest and provide license data
+
+    SPDX-License-Identifier: MIT
+    See LICENSES/MIT.md for more information.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import base64
+import json
+import re
+import time
+import zlib
+from functools import wraps
+
+import requests
+
+import resources.lib.common as common
+import resources.lib.kodi.ui as ui
+from resources.lib.globals import g
+from resources.lib.services.msl.exceptions import MSLError
+from resources.lib.services.msl.request_builder import MSLRequestBuilder
+
+try:  # Python 2
+    unicode
+except NameError:  # Python 3
+    unicode = str  # pylint: disable=redefined-builtin
+
+
+CHROME_BASE_URL = 'https://www.netflix.com/nq/msl_v1/cadmium/'
+ENDPOINTS = {
+    'manifest': CHROME_BASE_URL + 'pbo_manifests/%5E1.0.0/router',  # "pbo_manifests/^1.0.0/router"
+    'license': CHROME_BASE_URL + 'pbo_licenses/%5E1.0.0/router'
+}
+
+
+def display_error_info(func):
+    """Decorator that catches errors raise by the decorated function,
+    displays an error info dialog in the UI and reraises the error"""
+    # pylint: disable=missing-docstring
+    @wraps(func)
+    def error_catching_wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            ui.show_error_info(common.get_local_string(30028), unicode(exc),
+                               unknown_error=not(unicode(exc)),
+                               netflix_error=isinstance(exc, MSLError))
+            raise
+    return error_catching_wrapper
+
+
+class MSLHandlerBase(object):
+    """Handles session management and crypto for license, manifest and event requests"""
+    last_license_url = ''
+    last_drm_context = ''
+    last_playback_context = ''
+    session = requests.session()
+
+    def __init__(self):
+        self.request_builder = None
+
+    def check_mastertoken_validity(self):
+        """Return the mastertoken validity and executes a new key handshake when necessary"""
+        if self.request_builder.crypto.mastertoken:
+            time_now = time.time()
+            renewable = self.request_builder.crypto.renewal_window < time_now
+            expired = self.request_builder.crypto.expiration <= time_now
+        else:
+            renewable = False
+            expired = True
+        if expired:
+            if not self.request_builder.crypto.mastertoken:
+                common.debug('Stored MSL data not available, a new key handshake will be performed')
+                self.request_builder = MSLRequestBuilder()
+            else:
+                common.debug('Stored MSL data is expired, a new key handshake will be performed')
+            if self.perform_key_handshake():
+                self.request_builder = MSLRequestBuilder(json.loads(
+                    common.load_file('msl_data.json')))
+            return self.check_mastertoken_validity()
+        return {'renewable': renewable, 'expired': expired}
+
+
+    @display_error_info
+    @common.time_execution(immediate=True)
+    def perform_key_handshake(self, data=None):
+        """Perform a key handshake and initialize crypto keys"""
+        # pylint: disable=unused-argument
+        esn = data or g.get_esn()
+        if not esn:
+            common.info('Cannot perform key handshake, missing ESN')
+            return False
+
+        common.debug('Performing key handshake. ESN: {}', esn)
+
+        response = _process_json_response(
+            self._post(ENDPOINTS['manifest'],
+                       self.request_builder.handshake_request(esn)))
+        header_data = self.request_builder.decrypt_header_data(response['headerdata'], False)
+        self.request_builder.crypto.parse_key_response(header_data, not common.is_edge_esn(esn))
+        # Reset the user id token
+        self.request_builder.user_id_token = None
+        common.debug('Key handshake successful')
+        return True
+
+    @common.time_execution(immediate=True)
+    def _chunked_request(self, endpoint, request_data, esn, mt_validity=None):
+        """Do a POST request and process the chunked response"""
+        chunked_response = self._process_chunked_response(
+            self._post(endpoint, self.request_builder.msl_request(request_data, esn)),
+            mt_validity['renewable'] if mt_validity else None)
+        return chunked_response['result']
+
+    @common.time_execution(immediate=True)
+    def _post(self, endpoint, request_data):
+        """Execute a post request"""
+        common.debug('Executing POST request to {}', endpoint)
+        start = time.clock()
+        response = self.session.post(endpoint, request_data)
+        common.debug('Request took {}s', time.clock() - start)
+        common.debug('Request returned response with status {}', response.status_code)
+        response.raise_for_status()
+        return response
+
+    # pylint: disable=unused-argument
+    @common.time_execution(immediate=True)
+    def _process_chunked_response(self, response, mt_renewable):
+        """Parse and decrypt an encrypted chunked response. Raise an error
+        if the response is plaintext json"""
+        try:
+            # if the json() does not fail we have an error because
+            # the expected response is a chunked json response
+            return _raise_if_error(response.json())
+        except ValueError:
+            # json() failed so parse and decrypt the chunked response
+            common.debug('Received encrypted chunked response')
+            response = _parse_chunks(response.text)
+            # TODO: sending for the renewal request is not yet implemented
+            # if mt_renewable:
+            #     # Check if mastertoken is renewed
+            #     self.request_builder.crypto.compare_mastertoken(response['header']['mastertoken'])
+
+            header_data = self.request_builder.decrypt_header_data(
+                response['header'].get('headerdata'))
+
+            if 'useridtoken' in header_data:
+                # After the first call, it is possible get the 'user id token' that contains the
+                # user identity to use instead of 'User Authentication Data' with user credentials
+                self.request_builder.user_id_token = header_data['useridtoken']
+            # if 'keyresponsedata' in header_data:
+            #     common.debug('Found key handshake in response data')
+            #     # Update current mastertoken
+            #     self.request_builder.crypto.parse_key_response(header_data, True)
+            decrypted_response = _decrypt_chunks(response['payloads'], self.request_builder.crypto)
+            return _raise_if_error(decrypted_response)
+
+
+@common.time_execution(immediate=True)
+def _process_json_response(response):
+    """Execute a post request and expect a JSON response"""
+    try:
+        return _raise_if_error(response.json())
+    except ValueError:
+        raise MSLError('Expected JSON response, got {}'.format(response.text))
+
+
+def _raise_if_error(decoded_response):
+    raise_error = False
+    # Catch a manifest/chunk error
+    if any(key in decoded_response for key in ['error', 'errordata']):
+        raise_error = True
+    # Catch a license error
+    if 'result' in decoded_response and isinstance(decoded_response.get('result'), list):
+        if 'error' in decoded_response['result'][0]:
+            raise_error = True
+    if raise_error:
+        common.error('Full MSL error information:')
+        common.error(json.dumps(decoded_response))
+        raise MSLError(_get_error_details(decoded_response))
+    return decoded_response
+
+
+def _get_error_details(decoded_response):
+    # Catch a chunk error
+    if 'errordata' in decoded_response:
+        return json.loads(
+            base64.standard_b64decode(
+                decoded_response['errordata']))['errormsg']
+    # Catch a manifest error
+    if 'error' in decoded_response:
+        if decoded_response['error'].get('errorDisplayMessage'):
+            return decoded_response['error']['errorDisplayMessage']
+    # Catch a license error
+    if 'result' in decoded_response and isinstance(decoded_response.get('result'), list):
+        if 'error' in decoded_response['result'][0]:
+            if decoded_response['result'][0]['error'].get('errorDisplayMessage'):
+                return decoded_response['result'][0]['error']['errorDisplayMessage']
+    return 'Unhandled error check log.'
+
+
+@common.time_execution(immediate=True)
+def _parse_chunks(message):
+    header = json.loads(message.split('}}')[0] + '}}')
+    payloads = re.split(',\"signature\":\"[0-9A-Za-z=/+]+\"}',
+                        message.split('}}')[1])
+    payloads = [x + '}' for x in payloads][:-1]
+    return {'header': header, 'payloads': payloads}
+
+
+@common.time_execution(immediate=True)
+def _decrypt_chunks(chunks, crypto):
+    decrypted_payload = ''
+    for chunk in chunks:
+        payloadchunk = json.loads(chunk)
+        payload = payloadchunk.get('payload')
+        decoded_payload = base64.standard_b64decode(payload)
+        encryption_envelope = json.loads(decoded_payload)
+        # Decrypt the text
+        plaintext = crypto.decrypt(
+            base64.standard_b64decode(encryption_envelope['iv']),
+            base64.standard_b64decode(encryption_envelope.get('ciphertext')))
+        # unpad the plaintext
+        plaintext = json.loads(plaintext)
+        data = plaintext.get('data')
+
+        # uncompress data if compressed
+        if plaintext.get('compressionalgo') == 'GZIP':
+            decoded_data = base64.standard_b64decode(data)
+            data = zlib.decompress(decoded_data, 16 + zlib.MAX_WBITS).decode('utf-8')
+        else:
+            data = base64.standard_b64decode(data).decode('utf-8')
+
+        decrypted_payload += data
+
+    return json.loads(decrypted_payload)

--- a/resources/lib/services/msl/msl_handler_base.py
+++ b/resources/lib/services/msl/msl_handler_base.py
@@ -85,7 +85,6 @@ class MSLHandlerBase(object):
             return self.check_mastertoken_validity()
         return {'renewable': renewable, 'expired': expired}
 
-
     @display_error_info
     @common.time_execution(immediate=True)
     def perform_key_handshake(self, data=None):

--- a/resources/lib/services/msl/msl_handler_base.py
+++ b/resources/lib/services/msl/msl_handler_base.py
@@ -109,7 +109,7 @@ class MSLHandlerBase(object):
         return True
 
     @common.time_execution(immediate=True)
-    def _chunked_request(self, endpoint, request_data, esn, mt_validity=None):
+    def chunked_request(self, endpoint, request_data, esn, mt_validity=None):
         """Do a POST request and process the chunked response"""
         chunked_response = self._process_chunked_response(
             self._post(endpoint, self.request_builder.msl_request(request_data, esn)),

--- a/resources/lib/services/nfsession/nfsession_requests.py
+++ b/resources/lib/services/nfsession/nfsession_requests.py
@@ -112,7 +112,7 @@ class NFSessionRequests(NFSessionBase):
         """Refresh session_data from the Netflix website"""
         # pylint: disable=broad-except
         try:
-            website.extract_session_data(self._get('profiles'))
+            self.auth_url = website.extract_session_data(self._get('profiles'))['auth_url']
             self.update_session_data()
             common.debug('Successfully refreshed session data')
             return True

--- a/resources/lib/services/playback/action_manager.py
+++ b/resources/lib/services/playback/action_manager.py
@@ -64,6 +64,18 @@ class PlaybackActionManager(object):
         """
         self._call_if_enabled(self._on_tick, player_state=player_state)
 
+    def on_playback_seek(self, player_state):
+        """
+        Notify that a playback has seek
+        """
+        self._call_if_enabled(self._on_playback_seek, player_state=player_state)
+
+    def on_playback_pause(self, player_state):
+        """
+        Notify that the playback is actually in pause
+        """
+        self._call_if_enabled(self._on_playback_pause, player_state=player_state)
+
     def on_playback_stopped(self):
         """
         Notify that a playback has stopped
@@ -88,6 +100,12 @@ class PlaybackActionManager(object):
 
     def _on_tick(self, player_state):
         raise NotImplementedError
+
+    def _on_playback_seek(self, player_state):
+        pass
+
+    def _on_playback_pause(self, player_state):
+        pass
 
     def _on_playback_stopped(self):
         pass

--- a/resources/lib/services/playback/action_manager.py
+++ b/resources/lib/services/playback/action_manager.py
@@ -91,14 +91,25 @@ class PlaybackActionManager(object):
         """
         Initialize the manager for a new playback.
         If preconditions are not met, this should raise an exception so the
-        manager will be disabled throught the current playback.
+        manager will be disabled through the current playback.
         """
         raise NotImplementedError
 
     def _on_playback_started(self, player_state):
+        """
+        This method is called when video playback starts
+        NOTE: If possible never use sleep delay inside this method
+              otherwise it delay the execution of subsequent action managers
+        """
         pass
 
     def _on_tick(self, player_state):
+        """
+        This method is called every second from the service,
+        but only after the 'on_playback_started' method will be called.
+        NOTE: If possible never use sleep delay inside this method
+              otherwise it delay the execution of subsequent action managers
+        """
         raise NotImplementedError
 
     def _on_playback_seek(self, player_state):

--- a/resources/lib/services/playback/action_manager.py
+++ b/resources/lib/services/playback/action_manager.py
@@ -101,7 +101,6 @@ class PlaybackActionManager(object):
         NOTE: If possible never use sleep delay inside this method
               otherwise it delay the execution of subsequent action managers
         """
-        pass
 
     def _on_tick(self, player_state):
         """

--- a/resources/lib/services/playback/action_manager.py
+++ b/resources/lib/services/playback/action_manager.py
@@ -76,6 +76,12 @@ class PlaybackActionManager(object):
         """
         self._call_if_enabled(self._on_playback_pause, player_state=player_state)
 
+    def on_playback_resume(self, player_state):
+        """
+        Notify that the playback has been resumed
+        """
+        self._call_if_enabled(self._on_playback_resume, player_state=player_state)
+
     def on_playback_stopped(self):
         """
         Notify that a playback has stopped
@@ -115,6 +121,9 @@ class PlaybackActionManager(object):
         pass
 
     def _on_playback_pause(self, player_state):
+        pass
+
+    def _on_playback_resume(self, player_state):
         pass
 
     def _on_playback_stopped(self):

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -121,6 +121,8 @@ class PlaybackController(xbmc.Monitor):
     def _on_playback_stopped(self):
         self.tracking = False
         self.active_player_id = None
+        # Immediately send the request to release the license
+        common.send_signal(signal=common.Signals.RELEASE_LICENSE, non_blocking=True)
         self._notify_all(PlaybackActionManager.on_playback_stopped)
         self.action_managers = None
 

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -17,6 +17,7 @@ import xbmc
 import resources.lib.common as common
 from resources.lib.globals import g
 from .action_manager import PlaybackActionManager
+from .progress_manager import ProgressManager
 from .resume_manager import ResumeManager
 from .section_skipping import SectionSkipper
 from .stream_continuity import StreamContinuityManager
@@ -49,7 +50,8 @@ class PlaybackController(xbmc.Monitor):
             ResumeManager(),
             SectionSkipper(),
             StreamContinuityManager(),
-            UpNextNotifier()
+            UpNextNotifier(),
+            ProgressManager()
         ]
         self._notify_all(PlaybackActionManager.initialize, data)
 

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -67,6 +67,10 @@ class PlaybackController(xbmc.Monitor):
                 # Because when UpNext addon play a video while we are inside Netflix addon and
                 # not externally like Kodi library, the playerid become -1 this id does not exist
                 self._on_playback_started()
+            elif method == 'Player.OnSeek':
+                self._on_playback_seek()
+            elif method == 'Player.OnPause':
+                self._on_playback_pause()
             elif method == 'Player.OnStop':
                 self._on_playback_stopped()
         except Exception:
@@ -87,6 +91,20 @@ class PlaybackController(xbmc.Monitor):
         self._notify_all(PlaybackActionManager.on_playback_started, self._get_player_state())
         if common.is_debug_verbose() and g.ADDON.getSettingBool('show_codec_info'):
             common.json_rpc('Input.ExecuteAction', {'action': 'codecinfo'})
+
+    def _on_playback_seek(self):
+        if self.tracking and self.active_player_id is not None:
+            player_state = self._get_player_state()
+            if player_state:
+                self._notify_all(PlaybackActionManager.on_playback_seek,
+                                 player_state)
+
+    def _on_playback_pause(self):
+        if self.tracking and self.active_player_id is not None:
+            player_state = self._get_player_state()
+            if player_state:
+                self._notify_all(PlaybackActionManager.on_playback_pause,
+                                 player_state)
 
     def _on_playback_stopped(self):
         self.tracking = False

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -73,6 +73,8 @@ class PlaybackController(xbmc.Monitor):
                 self._on_playback_seek()
             elif method == 'Player.OnPause':
                 self._on_playback_pause()
+            elif method == 'Player.OnResume':
+                self._on_playback_resume()
             elif method == 'Player.OnStop':
                 self._on_playback_stopped()
         except Exception:
@@ -107,6 +109,13 @@ class PlaybackController(xbmc.Monitor):
             player_state = self._get_player_state()
             if player_state:
                 self._notify_all(PlaybackActionManager.on_playback_pause,
+                                 player_state)
+
+    def _on_playback_resume(self):
+        if self.tracking and self.active_player_id is not None:
+            player_state = self._get_player_state()
+            if player_state:
+                self._notify_all(PlaybackActionManager.on_playback_resume,
                                  player_state)
 
     def _on_playback_stopped(self):

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -128,6 +128,7 @@ class PlaybackController(xbmc.Monitor):
                 'properties': [
                     'audiostreams',
                     'currentaudiostream',
+                    'currentvideostream',
                     'subtitles',
                     'currentsubtitle',
                     'subtitleenabled',

--- a/resources/lib/services/playback/controller.py
+++ b/resources/lib/services/playback/controller.py
@@ -50,8 +50,8 @@ class PlaybackController(xbmc.Monitor):
             ResumeManager(),
             SectionSkipper(),
             StreamContinuityManager(),
-            UpNextNotifier(),
-            ProgressManager()
+            ProgressManager(),
+            UpNextNotifier()
         ]
         self._notify_all(PlaybackActionManager.initialize, data)
 
@@ -79,7 +79,7 @@ class PlaybackController(xbmc.Monitor):
             import traceback
             common.error(traceback.format_exc())
 
-    def on_playback_tick(self):
+    def on_service_tick(self):
         """
         Notify action managers of playback tick
         """
@@ -89,10 +89,11 @@ class PlaybackController(xbmc.Monitor):
                 self._notify_all(PlaybackActionManager.on_tick, player_state)
 
     def _on_playback_started(self):
-        self.active_player_id = _get_player_id()
-        self._notify_all(PlaybackActionManager.on_playback_started, self._get_player_state())
+        player_id = _get_player_id()
+        self._notify_all(PlaybackActionManager.on_playback_started, self._get_player_state(player_id))
         if common.is_debug_verbose() and g.ADDON.getSettingBool('show_codec_info'):
             common.json_rpc('Input.ExecuteAction', {'action': 'codecinfo'})
+        self.active_player_id = player_id
 
     def _on_playback_seek(self):
         if self.tracking and self.active_player_id is not None:
@@ -120,10 +121,10 @@ class PlaybackController(xbmc.Monitor):
         for manager in self.action_managers:
             _notify_managers(manager, notification, data)
 
-    def _get_player_state(self):
+    def _get_player_state(self, player_id=None):
         try:
             player_state = common.json_rpc('Player.GetProperties', {
-                'playerid': self.active_player_id,
+                'playerid': self.active_player_id or player_id,
                 'properties': [
                     'audiostreams',
                     'currentaudiostream',

--- a/resources/lib/services/playback/progress_manager.py
+++ b/resources/lib/services/playback/progress_manager.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2017 Sebastian Golasch (plugin.video.netflix)
+    Copyright (C) 2019 Stefano Gottardo - @CastagnaIT (original implementation module)
+    Manages events to send to the netflix service for the progress of the played video
+
+    SPDX-License-Identifier: MIT
+    See LICENSES/MIT.md for more information.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import resources.lib.common as common
+
+from .action_manager import PlaybackActionManager
+
+
+class ProgressManager(PlaybackActionManager):
+    """Detect the progress of the played video and send the data to the netflix service"""
+
+    def __init__(self):  # pylint: disable=super-on-old-class
+        super(ProgressManager, self).__init__()
+        self.current_videoid = None
+        self.wait_for_first_start_event = True
+        self.last_tick_count = 0
+        self.tick_elapsed = 0
+        self.last_player_state = {}
+        self.is_video_started = False
+
+    def _initialize(self, data):
+        videoid = common.VideoId.from_dict(data['videoid'])
+        if videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
+            self.enabled = False
+            return
+        self.current_videoid = videoid \
+            if videoid.mediatype == common.VideoId.MOVIE \
+            else videoid.derive_parent(0)
+
+    def _on_playback_started(self, player_state):
+        self.tick_elapsed = 0
+        self.player_elapsed_time = 0
+        self.send_first_start_event = True
+        self.is_video_started = True
+
+    def _on_tick(self, player_state):
+        if not self.is_video_started:
+            return
+        if self.wait_for_first_start_event:
+            # Before start we have to wait a possible values changed by stream_continuity
+            if self.tick_elapsed == 2:
+                # Is needed to wait at least 2 seconds
+                self.wait_for_first_start_event = False
+        else:
+            # Generate events to send to Netflix service every 1 minute
+            if (self.tick_elapsed - self.last_tick_count) / 60 >= 1:
+                # Todo: identify a possible fast forward / rewind
+                #       send event
+                self.last_tick_count = self.tick_elapsed
+        self.last_player_state = player_state
+
+        # Todo: One tick should be one second but _on_tick is called in sequence between all classes,
+        #       then will have to be reviewed in the future
+        self.tick_elapsed += 1  # One tick is one second
+
+    def _on_playback_stopped(self):
+        # Generate events to send to Netflix service
+        # Todo: send event
+        pass

--- a/resources/lib/services/playback/progress_manager.py
+++ b/resources/lib/services/playback/progress_manager.py
@@ -50,6 +50,7 @@ class ProgressManager(PlaybackActionManager):
             # Before start we have to wait a possible values changed by stream_continuity
             if self.tick_elapsed == 2:
                 # Is needed to wait at least 2 seconds
+                player_state['elapsed_seconds'] = 0  # Force set to 0
                 _send_event(EVENT_START, self.event_data, player_state)
                 self.wait_for_first_start_event = False
         else:

--- a/resources/lib/services/playback/progress_manager.py
+++ b/resources/lib/services/playback/progress_manager.py
@@ -10,7 +10,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import resources.lib.common as common
-from resources.lib.services.msl.events_handler import EVENT_STOP, EVENT_KEEP_ALIVE, EVENT_START
+from resources.lib.services.msl.events_handler import EVENT_STOP, EVENT_KEEP_ALIVE, EVENT_START, EVENT_ENGAGE
 from .action_manager import PlaybackActionManager
 
 
@@ -48,13 +48,22 @@ class ProgressManager(PlaybackActionManager):
         else:
             # Generate events to send to Netflix service every 1 minute
             if (self.tick_elapsed - self.last_tick_count) / 60 >= 1:
-                # Todo: identify a possible fast forward / rewind
                 _send_event(EVENT_KEEP_ALIVE, self.event_data, player_state)
                 self.last_tick_count = self.tick_elapsed
         self.last_player_state = player_state
         self.tick_elapsed += 1  # One tick almost always represents one second
 
+    def on_playback_pause(self, player_state):
+        self.tick_elapsed = 0
+        _send_event(EVENT_ENGAGE, self.event_data, player_state)
+
+    def on_playback_seek(self, player_state):
+        self.tick_elapsed = 0
+        _send_event(EVENT_ENGAGE, self.event_data, player_state)
+
     def _on_playback_stopped(self):
+        self.tick_elapsed = 0
+        _send_event(EVENT_ENGAGE, self.event_data, self.last_player_state)
         _send_event(EVENT_STOP, self.event_data, self.last_player_state)
 
 

--- a/resources/lib/services/playback/stream_continuity.py
+++ b/resources/lib/services/playback/stream_continuity.py
@@ -48,13 +48,11 @@ class StreamContinuityManager(PlaybackActionManager):
         self.sc_settings = {}
         self.player = xbmc.Player()
         self.player_state = {}
-        self.did_restore = False
         self.resume = {}
         self.legacy_kodi_version = bool('18.' in common.GetKodiVersion().version)
         self.kodi_only_forced_subtitles = None
 
     def _initialize(self, data):
-        self.did_restore = False
         videoid = common.VideoId.from_dict(data['videoid'])
         if videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
             self.enabled = False
@@ -81,13 +79,9 @@ class StreamContinuityManager(PlaybackActionManager):
             self._restore_stream(stype)
         # It is mandatory to wait at least 1 second to allow the Kodi system to update the values
         # changed by restore, otherwise when _on_tick is executed it will save twice unnecessarily
-        xbmc.sleep(1500)
-        self.did_restore = True
+        xbmc.sleep(1000)
 
     def _on_tick(self, player_state):
-        if not self.did_restore:
-            common.debug('Did not restore streams yet, ignoring tick')
-            return
         self.player_state = player_state
         # Check if the audio stream is changed
         current_stream = self.current_streams['audio']

--- a/resources/lib/upgrade_controller.py
+++ b/resources/lib/upgrade_controller.py
@@ -76,7 +76,7 @@ def _perform_local_db_changes(db_version):
 
 def _perform_shared_db_changes(db_version):
     """Perform database actions for a db version change"""
-    db_new_version = '0.1'
+    db_new_version = '0.2'
     if db_version != db_new_version:
         from resources.lib.common import debug
         debug('Initialization of shared database updates from version {} to {})',

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -110,7 +110,7 @@
     <setting id="ResumeManager_enabled" type="bool" label="30176" default="true"/>
     <setting id="ResumeManager_dialog" type="bool" label="30177" default="true" visible="eq(-1,true)" subsetting="true"/>
     <setting id="forced_subtitle_workaround" type="bool" label="30181" default="true" />
-    <setting id="ProgressManager_enabled" type="bool" label="30500" default="false"/>
+    <setting id="ProgressManager_enabled" type="bool" label="30235" default="false"/>
   </category>
   <category label="30023"><!--Expert-->
     <setting id="is_settings" type="action" label="30035" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)" option="close"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -110,6 +110,7 @@
     <setting id="ResumeManager_enabled" type="bool" label="30176" default="true"/>
     <setting id="ResumeManager_dialog" type="bool" label="30177" default="true" visible="eq(-1,true)" subsetting="true"/>
     <setting id="forced_subtitle_workaround" type="bool" label="30181" default="true" />
+    <setting id="ProgressManager_enabled" type="bool" label="30500" default="true"/>
   </category>
   <category label="30023"><!--Expert-->
     <setting id="is_settings" type="action" label="30035" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)" option="close"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -110,7 +110,7 @@
     <setting id="ResumeManager_enabled" type="bool" label="30176" default="true"/>
     <setting id="ResumeManager_dialog" type="bool" label="30177" default="true" visible="eq(-1,true)" subsetting="true"/>
     <setting id="forced_subtitle_workaround" type="bool" label="30181" default="true" />
-    <setting id="ProgressManager_enabled" type="bool" label="30500" default="true"/>
+    <setting id="ProgressManager_enabled" type="bool" label="30500" default="false"/>
   </category>
   <category label="30023"><!--Expert-->
     <setting id="is_settings" type="action" label="30035" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)" option="close"/>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
With this PR begins experimentation to communicate information about the progress and watched status to the Netflix service in a two way communication.

**This PR will add this functionality only for videos running within the addon, then not from Kodi library**, for the management of progress status in the Kodi library will be done on another PR

NO ETA - NO QUESTIONS THAT ARE NOT HELPFUL

Anyone with additional information to help developing with service is welcome to

~**Highly experimental** branch, all can change frequently and completely, as needed~

1. PHASE: Implement a first version of event data system [DONE]
2. PHASE: Try to send progress state to nf service [DONE]
3. PHASE: Optimize event data system [DONE]
4. PHASE: Try to get the progress state from nf [DONE]
5. PHASE: Implement start video from an previous existing time position [DONE]
6. PHASE: Override Kodi watched status integration and implement all this as optional setting [DONE]

_Started tests before release it_

~I'm not sure that the work will be finished and i'm not able to say if it will be successful,
but to now finally i got a starting point on which to perform tests~

Discussion issue: https://github.com/CastagnaIT/plugin.video.netflix/issues/80

Current limitations:
- Works only with main profile (solution found! read below)
- The continue watching list will not be updated

How works (Wiki added):
- By default this feature is disabled, can be enabled on:
Settings->Playback->Send/Receive progress and watched status of the videos
- When enabled _all previous watched status and progress will be replaced_ by those on the website (until you disable the option)
- When you start a video playback, the "resume" feature will be updated only after watching at least the first minute of the video.
- The synchronization from Kodi to the Netflix service is immediate
- When the videos progress are changed by other devices and Kodi at the same time, in Kodi you may not see immediately the changes made by other devices. To see immediately the changes you need to _purge cache_ (or reboot Kodi).

Unresolved problems:

I FINALLY FOUND THE SOLUTION!🎉🎉🎉🎊🎊
Exists a MSL switch! and with the latest changes made it worked!
I was able to use it and communicate the data and make data requests from the right profiles!
but it is quite complicated to implement it... i think there will be a need to unify MSL and nfsession, as i suspected in the past, and this solves all the problems mentioned below!!! (except for continue watching)

will be implemented in the future with other PR because it requires different work

<pre>
The first tests were a success, only problem is the communication of MSL data in to the right profile, currently all data is sent only to the main profile

I tried these tests but failed:
-sending manifest/license requests through the nfsession does not solve the problem
-After added commit to get the "lhpuuidh-browse" cookies the situation is not changed

this problem is the same one involving other problems:
-missing audio/subtitle language on other profiles with different language set
-playing videos from a Kid profile, not give age error, this because the manifest request is always done from the main profile, then "every play" is from the main profile
</pre>

The continue watching list is not updated, i tried to implement `refreshListByContext` and `refreshVideoCurrentPositions` but they do not perform the desired effect...
