### PR TITLE
Removed per profile watched settings

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -959,7 +959,3 @@ msgstr "Einschränkung nach Alterseinstufung"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Um den Inhalt für {} abzuspielen ist die Eingabe Ihrer PIN erforderlich."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Gesehen-Status für jedes Profil separat markieren (diese Einstellung wird in zukünftigen Versionen entfernt)"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -959,7 +959,3 @@ msgstr ""
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr ""
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -959,7 +959,3 @@ msgstr "Restringir por grado de madurez"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "El contenido para {} requerirá el PIN para iniciar la reproducción."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Mantener marcas de estado 'visto' separadas para cada perfil (esta opción se eliminará en versiones futuras)"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -959,7 +959,3 @@ msgstr "Accès restreint à une certaine catégorie d'âge"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Le contenu pour {} nécessite le code PIN pour être visionné."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Garder le statut vu séparé pour chaque profil (cette option sera supprimée dans les prochaines versions)"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -960,7 +960,3 @@ msgstr "Ograniči prema razini zrelosti"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Za sadržaj {} bit će potreban PIN da bi se započela reprodukcija."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Oznake statusa gledanja držite odvojeno za svaki profil (ova će opcija biti uklonjena u budućim verzijama)"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -959,7 +959,3 @@ msgstr "Életkor szerint korlátozva"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Tartalom {} meg kell adni a pinkódot a lejátszáshoz."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Nézett státusz minden profilhoz (ez az opció visszavonásra kerül a jövőben)"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -959,7 +959,3 @@ msgstr "Limitazione in base alla fascia d'età"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Per riprodurre i contenuti per {} è necessario il PIN."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Mantieni la spunta guardato separata per ogni profilo (nelle future versioni questa opzione sarà rimossa)"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -959,7 +959,3 @@ msgstr "成人向け"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "{}を見るのにはPINを入力してください"
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "プロフィール毎に見た項目の一覧を保存します(この機能は将来に無くなります)"

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -959,7 +959,3 @@ msgstr "연령제한"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "{}을(를) 보려면 PIN을 입력하십시오."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "프로파일마다 이미 본 것들을 따로 저장합니다(이기능은 나중에 없어집니다)"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -959,7 +959,3 @@ msgstr "Ogranicz według poziomu dojrzałości"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Zawartość dla {} będzie wymagała kodu PIN do odtworzenia"
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Zachowaj status oglądania osobno dla każdego profilu (ta opcja zostanie usunięta w przyszłych wersjach)"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -959,7 +959,3 @@ msgstr "Restringir por Nível de Maturidade"
 msgctxt "#30233"
 msgid "Content for {} will require the PIN to start playback."
 msgstr "Conteúdo para {} irá requerer o PIN para iniciar a reprodução."
-
-msgctxt "#30234"
-msgid "Keep watched status marks separate for each profile (this option will be removed in future versions)"
-msgstr "Mantenha as marcas de status assistidas separadas para cada perfil (essa opção será removida em versões futuras)"

--- a/resources/lib/kodi/listings.py
+++ b/resources/lib/kodi/listings.py
@@ -477,15 +477,10 @@ def add_sort_methods(sort_type):
         xbmcplugin.addSortMethod(g.PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_TITLE)
 
 
-# This method is a temporary option transition for the current users to avoid causing frustration
-# because when enabled causes the loss of all watched status already assigned to the videos,
-# in future versions will have to be eliminated, keeping params.
 def get_param_watched_status_by_profile():
     """
-    When enabled, the value to be used as parameter in the ListItem (of videos) will be created,
-    in order to differentiate the watched status by profiles
-    :return: when enabled return a dictionary to be add to 'build_url' params
+    Get a value used as parameter in the ListItem (of videos),
+    in order to differentiate the watched status and other Kodi data by profiles
+    :return: a dictionary to be add to 'build_url' params
     """
-    if g.ADDON.getSettingBool('watched_status_by_profile'):
-        return {'profile_guid': g.LOCAL_DB.get_active_profile_guid()}
-    return None
+    return {'profile_guid': g.LOCAL_DB.get_active_profile_guid()}

--- a/resources/lib/upgrade_controller.py
+++ b/resources/lib/upgrade_controller.py
@@ -48,17 +48,6 @@ def _perform_addon_changes(previous_ver, current_ver):
         msg = ('This update resets the settings to auto-update library.\r\n'
                'Therefore only in case you are using auto-update must be reconfigured.')
         ui.show_ok_dialog('Netflix upgrade', msg)
-    if previous_ver and is_less_version(previous_ver, '0.16.0'):
-        import resources.lib.kodi.ui as ui
-        msg = (
-            'Has been introduced watched status marks for the videos separate for each profile:\r\n'
-            '[Use new feature] watched status will be separate by profile, [B]existing watched status will be lost.[/B]\r\n'
-            '[Leave unchanged] existing watched status will be kept, [B]but in future versions will be lost.[/B]\r\n'
-            'This option can be temporarily changed in expert settings')
-        choice = ui.show_yesno_dialog('Netflix upgrade - watched status marks', msg,
-                                      'Use new feature', 'Leave unchanged')
-        g.settings_monitor_suspend(at_first_change=True)
-        g.ADDON.setSettingBool('watched_status_by_profile', choice)
     # Clear cache (prevents problems when netflix change data structures)
     g.CACHE.invalidate(True)
     # Always leave this to last - After the operations set current version

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -134,7 +134,6 @@
     <setting id="enable_timing" type="bool" label="30134" default="false"/>
     <setting id="disable_modal_error_display" type="bool" label="30130" default="false"/>
     <setting id="ssl_verification" type="bool" label="30024" default="true"/>
-    <setting id="watched_status_by_profile" type="bool" label="30234" default="true"/> <!-- This is a temporary transition option -->
     <setting label="30117" type="lsep"/><!--Cache-->
     <setting id="cache_ttl" type="slider" option="int" range="0,10,525600" label="30084" default="120"/>
     <setting id="cache_metadata_ttl" type="slider" option="int" range="0,1,365" label="30085" default="30"/>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
As already mentioned in previous PRs, the route to achieve a possible transmission of video data such as progress and watched status at netflix must go ahead.

Therefore this option should be deleted, which however sharing data between profiles has always been wrong since the beginning of the development of this add-on

_About a month ago everyone was notified, by message at the start of the add-on and in the forum thread,
anyone who ignores the warning message, and did not perform the "migration", will lose all watched video status inside the add-on (so not Kodi library)_

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
