### PR TITLE
Handled not available metadata

### DIFF
--- a/resources/lib/api/exceptions.py
+++ b/resources/lib/api/exceptions.py
@@ -58,3 +58,7 @@ class APIError(Exception):
 
 class NotConnected(Exception):
     """Internet status not connected"""
+
+
+class MetadataNotAvailable(Exception):
+    """Metadata not found"""

--- a/resources/lib/common/misc_utils.py
+++ b/resources/lib/common/misc_utils.py
@@ -196,6 +196,8 @@ def execute_tasks(title, tasks, task_handler, **kwargs):
 #        xbmc.sleep(25)
         if progress.iscanceled():
             break
+        if not task:
+            continue
         try:
             task_handler(task, **kwargs)
         except Exception as exc:

--- a/resources/lib/kodi/library_items.py
+++ b/resources/lib/kodi/library_items.py
@@ -19,6 +19,7 @@ import xbmcvfs
 import resources.lib.api.shakti as api
 import resources.lib.common as common
 import resources.lib.kodi.ui as ui
+from resources.lib.api.exceptions import MetadataNotAvailable
 from resources.lib.globals import g
 
 LIBRARY_HOME = 'library'
@@ -118,6 +119,8 @@ def get_previously_exported_items():
                     # and movies only contain one file
                     result.append(
                         _get_root_videoid(filepath, videoid_pattern))
+                except MetadataNotAvailable:
+                    common.warn('Metadata not available, item skipped')
                 except (AttributeError, IndexError):
                     common.warn('Item does not conform to old format')
                 break

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -13,6 +13,7 @@ import xbmc
 import xbmcplugin
 import xbmcgui
 
+from resources.lib.api.exceptions import MetadataNotAvailable
 from resources.lib.globals import g
 import resources.lib.common as common
 import resources.lib.api.shakti as api
@@ -51,8 +52,12 @@ class InputstreamError(Exception):
 def play(videoid):
     """Play an episode or movie as specified by the path"""
     common.info('Playing {}', videoid)
-    metadata = api.metadata(videoid)
-    common.debug('Metadata is {}', metadata)
+    metadata = [{}, {}]
+    try:
+        metadata = api.metadata(videoid)
+        common.debug('Metadata is {}', metadata)
+    except MetadataNotAvailable:
+        common.warn('Metadata not available for {}', videoid)
 
     # Parental control PIN
     pin_result = _verify_pin(metadata[0].get('requiresPin', False))


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
accidentally i came across the manual update of a tvshow exported from a Spanish profile, but i launched the manual update from a profile with Italian language,
this caused a metadata breach that broke the library update, becouse the tvshow spanish is not available in italy

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
