### PR TITLE
Sqlite connections and multi thread a way to solve

### DIFF
--- a/resources/lib/database/db_base.py
+++ b/resources/lib/database/db_base.py
@@ -16,7 +16,6 @@ class BaseDatabase(object):
     """
     def __init__(self):
         self.conn = None
-        self.is_connected = False
         self._initialize_connection()
 
     def _initialize_connection(self):


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
In the latest kodi builds a problem between shared connections between different threads has been highlighted, which was not present before or was present in a rare way always on linux devices (RPI and some Android). I don't understand why the problem's only just come up now.

This problem seem to be affected low power devices, can happen more easily than sqlite read/write with the same connection so causing side-effects to the sqlite module.

The main problem is that sqlite doesn't really support shared connections by several different threads and mishandles multiple readings/writings at same time. Even if `check_same_thread` can be turned off, unfortunately it can happen that despite the connection can be reused, an operation of one thread can invalidate that of another.

So causing errors like:
- SQLite error SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 139993100048128 and this is thread id 139993502701312.:
- SQLite error Cursor needed to be reset because of commit/rollback and can no longer be fetched from.:
- OperationalError: unable to close due to unfinalized statements or unfinished backups

Ref: https://github.com/CastagnaIT/plugin.video.netflix/issues/403
Android log: https://paste.kodi.tv/nonimukisu.kodi

At the moment the situation is very complex and not easily solveable, here depends:
- how code is managed in a reusable way
- multiple addon instance that can be running at same time
- multiple threads that running inside one addon instance
- the limitations of sqlite db system

It seems that by creating a mutex we can solve the problem sufficiently acceptably
without doing a complete restructuring of the code that maybe it wouldn't make much difference in the end

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
