### PR TITLE
Properties must not be shared with multiple kodi profiles

### DIFF
--- a/resources/lib/common/kodiops.py
+++ b/resources/lib/common/kodiops.py
@@ -137,6 +137,13 @@ def stop_playback():
     xbmc.executebuiltin('PlayerControl(Stop)')
 
 
+def get_current_kodi_profile_name(no_spaces=True):
+    """Gets the name of the Kodi profile currently used"""
+    name = json_rpc('Profiles.GetCurrentProfile',
+                    {'properties': ['thumbnail', 'lockmode']}).get('label', 'unknown')
+    return name.replace(' ', '_') if no_spaces else name
+
+
 def get_kodi_audio_language():
     """
     Return the audio language from Kodi settings

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -15,7 +15,8 @@ from xbmcgui import Window
 
 from resources.lib.globals import g
 from resources.lib.common import (info, debug, warn, error, check_credentials, BackendNotReady,
-                                  log_time_trace, reset_log_level_global_var)
+                                  log_time_trace, reset_log_level_global_var,
+                                  get_current_kodi_profile_name)
 from resources.lib.upgrade_controller import check_addon_upgrade
 
 
@@ -66,7 +67,7 @@ def route(pathitems):
     execute(_get_nav_handler(root_handler), pathitems[1:], g.REQUEST_PARAMS)
 
 
-def _skin_widget_call(window_cls):
+def _skin_widget_call(window_cls, prop_nf_service_status):
     """
     Workaround to intercept calls made by the Skin Widgets currently in use.
     Currently, the Skin widgets associated with add-ons are executed at Kodi startup immediately
@@ -85,7 +86,7 @@ def _skin_widget_call(window_cls):
     if not getCondVisibility("Window.IsMedia"):
         monitor = Monitor()
         sec_elapsed = 0
-        while not window_cls.getProperty('nf_service_status') == 'running':
+        while not window_cls.getProperty(prop_nf_service_status) == 'running':
             if sec_elapsed >= limit_sec or monitor.abortRequested() or monitor.waitForAbort(0.5):
                 break
             sec_elapsed += 0.5
@@ -145,10 +146,12 @@ def run(argv):
     info('URL is {}'.format(g.URL))
     success = True
 
-    window_cls = Window(10000)
-    is_widget_skin_call = _skin_widget_call(window_cls)
+    window_cls = Window(10000)  # Kodi home window
+    # If you use multiple Kodi profiles you need to distinguish the property of current profile
+    prop_nf_service_status = 'nf_service_status_' + get_current_kodi_profile_name()
+    is_widget_skin_call = _skin_widget_call(window_cls, prop_nf_service_status)
 
-    if window_cls.getProperty('nf_service_status') != 'running':
+    if window_cls.getProperty(prop_nf_service_status) != 'running':
         if not is_widget_skin_call:
             from resources.lib.kodi.ui import show_backend_not_ready
             show_backend_not_ready()


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
The temporany cache data and service status are stored in the Kodi home page, so they can be shared between different instances and survive the sequential executions of the addon.

It was not expected that using multiple kodi profiles, these properties are not suppressed,
so these properties surviving through profile switch causes addon misbehaviour

may coexist but should not be shared but separated according to the profile used

ref. issue: https://github.com/CastagnaIT/plugin.video.netflix/issues/412
### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
