### PR TITLE
Improvements to open the addon faster

### DIFF
--- a/resources/lib/api/exceptions.py
+++ b/resources/lib/api/exceptions.py
@@ -31,8 +31,8 @@ class InvalidAuthURLError(WebsiteParsingError):
     """The authURL is invalid"""
 
 
-class InvalidProfilesError(WebsiteParsingError):
-    """Cannot extract profiles from Netflix webpage"""
+class InvalidProfilesError(Exception):
+    """Cannot get profiles data from Netflix"""
 
 
 class InvalidMembershipStatusError(WebsiteParsingError):

--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -24,6 +24,7 @@ from .paths import (VIDEO_LIST_PARTIAL_PATHS, VIDEO_LIST_BASIC_PARTIAL_PATHS,
                     TRAILER_PARTIAL_PATHS)
 from .exceptions import (InvalidVideoListTypeError, APIError, MissingCredentialsError,
                          MetadataNotAvailable)
+from .website import parse_profiles
 
 
 def catch_api_errors(func):
@@ -62,8 +63,14 @@ def login(ask_credentials=True):
 
 
 def update_profiles_data():
-    """Fetch profiles data from website"""
-    return common.make_call('update_profiles_data')
+    """Update the profiles list data to the database"""
+    profiles_data = common.make_call(
+        'path_request',
+        [['profilesList', 'summary'], ['profilesList', 'current', 'summary'],
+         ['profilesList', {'to': 5}, 'summary'], ['profilesList', {'to': 5},
+                                                  'avatar', 'images', 'byWidth', 320],
+         ['lolomo']])
+    parse_profiles(profiles_data)
 
 
 def activate_profile(profile_id):

--- a/resources/lib/kodi/listings.py
+++ b/resources/lib/kodi/listings.py
@@ -64,27 +64,19 @@ def _activate_view(partial_setting_id):
 @common.time_execution(immediate=False)
 def build_profiles_listing():
     """Builds the profiles list Kodi screen"""
-    try:
-        from HTMLParser import HTMLParser
-    except ImportError:
-        from html.parser import HTMLParser
-    html_parser = HTMLParser()
     directory_items = []
     active_guid_profile = g.LOCAL_DB.get_active_profile_guid()
     for guid in g.LOCAL_DB.get_guid_profiles():
-        directory_items.append(_create_profile_item(guid,
-                                                    (guid == active_guid_profile),
-                                                    html_parser))
+        directory_items.append(_create_profile_item(guid, (guid == active_guid_profile)))
     # The standard kodi theme does not allow to change view type if the content is "files" type,
     # so here we use "images" type, visually better to see
     finalize_directory(directory_items, g.CONTENT_IMAGES)
 
 
-def _create_profile_item(profile_guid, is_active, html_parser):
+def _create_profile_item(profile_guid, is_active):
     """Create a tuple that can be added to a Kodi directory that represents
     a profile as listed in the profiles listing"""
     profile_name = g.LOCAL_DB.get_profile_config('profileName', '', guid=profile_guid)
-    unescaped_profile_name = html_parser.unescape(profile_name)
     is_account_owner = g.LOCAL_DB.get_profile_config('isAccountOwner', False, guid=profile_guid)
     is_kids = g.LOCAL_DB.get_profile_config('isKids', False, guid=profile_guid)
     description = []
@@ -92,15 +84,14 @@ def _create_profile_item(profile_guid, is_active, html_parser):
         description.append(common.get_local_string(30221))
     if is_kids:
         description.append(common.get_local_string(30222))
-    enc_profile_name = profile_name.encode('utf-8')
     list_item = list_item_skeleton(
-        label=unescaped_profile_name,
+        label=profile_name,
         icon=g.LOCAL_DB.get_profile_config('avatar', '', guid=profile_guid),
         description=', '.join(description))
     list_item.select(is_active)
     autologin_url = common.build_url(
         pathitems=['save_autologin', profile_guid],
-        params={'autologin_user': enc_profile_name},
+        params={'autologin_user': profile_name.encode('utf-8')},
         mode=g.MODE_ACTION)
     list_item.addContextMenuItems(
         [(common.get_local_string(30053),

--- a/resources/lib/navigation/directory.py
+++ b/resources/lib/navigation/directory.py
@@ -59,9 +59,7 @@ class DirectoryBuilder(object):
         """Show profiles listing"""
         # pylint: disable=unused-argument
         common.debug('Showing profiles listing')
-        if not api.update_profiles_data():
-            xbmcplugin.endOfDirectory(g.PLUGIN_HANDLE, succeeded=False)
-            return
+        api.update_profiles_data()
         listings.build_profiles_listing()
         _handle_endofdirectory(False, False)
 

--- a/resources/lib/services/nfsession/nfsession.py
+++ b/resources/lib/services/nfsession/nfsession.py
@@ -30,7 +30,6 @@ class NetflixSession(NFSessionAccess):
         self.slots = [
             self.login,
             self.logout,
-            self.update_profiles_data,
             self.activate_profile,
             self.parental_control_data,
             self.path_request,
@@ -70,12 +69,6 @@ class NetflixSession(NFSessionAccess):
         extracted_content = website.extract_parental_control_data(response_content)
         extracted_content['pin'] = pin
         return extracted_content
-
-    @common.addonsignals_return_call
-    @needs_login
-    @common.time_execution(immediate=True)
-    def update_profiles_data(self):
-        return self.try_refresh_session_data(raise_exception=True)
 
     @common.addonsignals_return_call
     @needs_login

--- a/resources/lib/services/nfsession/nfsession.py
+++ b/resources/lib/services/nfsession/nfsession.py
@@ -37,6 +37,7 @@ class NetflixSession(NFSessionAccess):
             self.perpetual_path_request_switch_profiles,
             self.get,
             self.post,
+            self.startup_requests_module
         ]
         for slot in self.slots:
             common.register_slot(slot)

--- a/resources/lib/services/nfsession/nfsession_access.py
+++ b/resources/lib/services/nfsession/nfsession_access.py
@@ -56,7 +56,7 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
 
     @common.time_execution(immediate=True)
     def is_logged_in(self):
-        """Check if the user is logged in and if so refresh session data"""
+        """Check if there are valid login data"""
         valid_login = self._load_cookies() and \
             self._verify_session_cookies() and \
             self._verify_esn_existence()

--- a/resources/lib/services/nfsession/nfsession_access.py
+++ b/resources/lib/services/nfsession/nfsession_access.py
@@ -89,8 +89,7 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
                 'login',
                 data=_login_payload(common.get_credentials(), auth_url))
             try:
-                website.validate_login(login_response)
-                website.extract_session_data(login_response)
+                website.extract_session_data(login_response, validate=True)
                 common.info('Login successful')
                 ui.show_notification(common.get_local_string(30109))
                 self.update_session_data(current_esn)

--- a/resources/lib/services/nfsession/nfsession_access.py
+++ b/resources/lib/services/nfsession/nfsession_access.py
@@ -39,7 +39,7 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
         If so, do the login before the user requests it"""
         try:
             common.get_credentials()
-            if not self._is_logged_in():
+            if not self.is_logged_in():
                 self._login()
             self.is_prefetch_login = True
         except requests.exceptions.RequestException as exc:
@@ -55,7 +55,7 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
             ui.show_notification(common.get_local_string(30180), time=10000)
 
     @common.time_execution(immediate=True)
-    def _is_logged_in(self):
+    def is_logged_in(self):
         """Check if the user is logged in and if so refresh session data"""
         valid_login = self._load_cookies() and \
             self._verify_session_cookies() and \

--- a/resources/lib/services/nfsession/nfsession_access.py
+++ b/resources/lib/services/nfsession/nfsession_access.py
@@ -19,7 +19,7 @@ import resources.lib.common.cookies as cookies
 import resources.lib.api.website as website
 import resources.lib.kodi.ui as ui
 from resources.lib.globals import g
-from resources.lib.services.nfsession.nfsession_requests import NFSessionRequests
+from resources.lib.services.nfsession.nfsession_requests import NFSessionRequests, BASE_URL
 from resources.lib.services.nfsession.nfsession_cookie import NFSessionCookie
 from resources.lib.api.exceptions import (LoginFailedError, LoginValidateError,
                                           MissingCredentialsError, InvalidMembershipStatusError)
@@ -41,6 +41,9 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
             common.get_credentials()
             if not self.is_logged_in():
                 self._login()
+            else:
+                # A hack way to full load requests module without blocking the service startup
+                common.send_signal(signal='startup_requests_module')
             self.is_prefetch_login = True
         except requests.exceptions.RequestException as exc:
             # It was not possible to connect to the web service, no connection, network problem, etc
@@ -69,6 +72,13 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
         if not g.get_esn():
             return self.try_refresh_session_data()
         return True
+
+    def startup_requests_module(self, data=None):  # pylint: disable=unused-argument
+        """A hack way to full load requests module without blocking the service"""
+        # The first call made with 'requests' module, takes more than one second longer then usual
+        # to elaborate, i think it is better to do it when the service is started
+        # to camouflage this delay and make the add-on frontend faster
+        self.session.head(url=BASE_URL)
 
     @common.addonsignals_return_call
     def login(self):

--- a/resources/lib/services/nfsession/nfsession_base.py
+++ b/resources/lib/services/nfsession/nfsession_base.py
@@ -15,6 +15,7 @@ import requests
 
 import resources.lib.common as common
 import resources.lib.common.cookies as cookies
+from resources.lib.database.db_exceptions import ProfilesMissing
 from resources.lib.globals import g
 from resources.lib.database.db_utils import (TABLE_SESSION)
 from resources.lib.api.exceptions import (NotLoggedInError, NotConnected)
@@ -77,8 +78,12 @@ class NFSessionBase(object):
         _update_esn(old_esn)
 
     def set_session_header_data(self):
-        self.session.headers.update(
-            {'x-netflix.request.client.user.guid': g.LOCAL_DB.get_active_profile_guid()})
+        try:
+            # When the addon is installed from scratch there is no profiles in the database
+            self.session.headers.update(
+                {'x-netflix.request.client.user.guid': g.LOCAL_DB.get_active_profile_guid()})
+        except ProfilesMissing:
+            pass
 
     @property
     def account_hash(self):

--- a/resources/lib/services/nfsession/nfsession_base.py
+++ b/resources/lib/services/nfsession/nfsession_base.py
@@ -33,7 +33,7 @@ def needs_login(func):
         if not common.is_internet_connected():
             raise NotConnected('Internet connection not available')
         # ..this check verifies only if locally there are the data to correctly perform the login
-        if not session._is_logged_in():
+        if not session.is_logged_in():
             raise NotLoggedInError
         return func(*args, **kwargs)
     return ensure_login

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -133,7 +133,7 @@
     <setting id="enable_ipc_over_http" type="bool" label="30139" default="false"/>
     <setting id="enable_timing" type="bool" label="30134" default="false"/>
     <setting id="disable_modal_error_display" type="bool" label="30130" default="false"/>
-    <setting id="ssl_verification" type="bool" label="30024" default="true"/>
+    <setting id="ssl_verification" type="bool" label="30024" default="true" visible="false"/> <!-- just for developers -->
     <setting label="30117" type="lsep"/><!--Cache-->
     <setting id="cache_ttl" type="slider" option="int" range="0,10,525600" label="30084" default="120"/>
     <setting id="cache_metadata_ttl" type="slider" option="int" range="0,1,365" label="30085" default="30"/>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Some time ago i have found the path request to get the profiles list from the API,
was hidden among the Netflix html answers in the PostGateData.
This allows you to safely obtain the list of profiles avoiding parsing transformations, 
and also avoid parserizing the web page every time you return to the profiles screen,
this allow to open the profiles screen in about only 1 second! instead of 3 seconds or more!

I also noticed that the requests module takes from 2 to 3 seconds longer than normal to process the first call, this freezes the opening of the addon for a very long time,
so to camouflage this problem, ~i preferred to force the update of the session data~ an update of the session headers will be performed when the service is started this way you can recover about 2 seconds!

~Can be configured in expert settings, will make happy those who use only kodi library and/or widgets~

Execution time test before (at first run of the addon):
make_call                      3219 ms
Execution time test after (at first run of the addon):
make_call                      1310 ms

PS. the "seconds" specified above, are based on tests performed on Windows 10, with fairly high network latency compared to others, so in my configuration the result data (the seconds) are more accentuated

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
