### PR TITLE
fix: sqlite3 library deadlock

### DIFF
--- a/resources/lib/database/db_base_sqlite.py
+++ b/resources/lib/database/db_base_sqlite.py
@@ -49,7 +49,7 @@ def handle_connection(func):
             if not args[0].is_connected:
                 args[0].mutex.acquire()
                 args[0].conn = sql.connect(args[0].db_file_path,
-                                        isolation_level=CONN_ISOLATION_LEVEL)
+                                           isolation_level=CONN_ISOLATION_LEVEL)
                 args[0].is_connected = True
                 conn = args[0].conn
 

--- a/resources/lib/database/db_base_sqlite.py
+++ b/resources/lib/database/db_base_sqlite.py
@@ -10,19 +10,20 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import sqlite3 as sql
+import threading
 from functools import wraps
-from threading import Lock
+
+import resources.lib.common as common
+import resources.lib.database.db_base as db_base
+import resources.lib.database.db_create_sqlite as db_create_sqlite
+import resources.lib.database.db_utils as db_utils
+from resources.lib.database.db_exceptions import SQLiteConnectionError, SQLiteError
 
 try:  # Python 2
     from itertools import izip as zip  # pylint: disable=redefined-builtin
 except ImportError:
     pass
 
-import resources.lib.common as common
-import resources.lib.database.db_base as db_base
-import resources.lib.database.db_create_sqlite as db_create_sqlite
-import resources.lib.database.db_utils as db_utils
-from resources.lib.database.db_exceptions import (SQLiteConnectionError, SQLiteError)
 
 CONN_ISOLATION_LEVEL = None  # Autocommit mode
 
@@ -45,28 +46,41 @@ def handle_connection(func):
             return func(*args, **kwargs)
         conn = None
         try:
-            args[0].mutex.acquire()
-            args[0].conn = sql.connect(args[0].db_file_path,
-                                       isolation_level=CONN_ISOLATION_LEVEL)
-            conn = args[0].conn
+            if not args[0].is_connected:
+                args[0].mutex.acquire()
+                args[0].conn = sql.connect(args[0].db_file_path,
+                                        isolation_level=CONN_ISOLATION_LEVEL)
+                args[0].is_connected = True
+                conn = args[0].conn
+
             return func(*args, **kwargs)
         except sql.Error as exc:
             common.error('SQLite error {}:', exc.args[0])
             raise SQLiteConnectionError
         finally:
             if conn:
+                args[0].is_connected = False
                 conn.close()
-            args[0].mutex.release()
+                args[0].mutex.release()
     return wrapper
 
 
 class SQLiteDatabase(db_base.BaseDatabase):
     def __init__(self, db_filename):  # pylint: disable=super-on-old-class
-        self.mutex = Lock()
+        self.mutex = threading.Lock()
+        self.local_storage = threading.local()
         self.is_mysql_database = False
         self.db_filename = db_filename
         self.db_file_path = db_utils.get_local_db_path(db_filename)
         super(SQLiteDatabase, self).__init__()
+
+    @property
+    def is_connected(self):
+        return getattr(self.local_storage, 'is_connected', False)
+
+    @is_connected.setter
+    def is_connected(self, val):
+        self.local_storage.is_connected = val
 
     def _initialize_connection(self):
         try:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
Bug fix for sqlite3 library deadlock described here: https://github.com/CastagnaIT/plugin.video.netflix/issues/425

This still ensures that there is only 1 active thread with sqlite3 connection (which https://github.com/CastagnaIT/plugin.video.netflix/commit/3392a7e8c579a251dfd91aec530a62bd41777110 introduced) and it now correctly handles reentrant handle_connection decorators.
