### PR TITLE
Fix for http error 401 "Unauthorized for url"

### DIFF
--- a/resources/lib/services/nfsession/nfsession_access.py
+++ b/resources/lib/services/nfsession/nfsession_access.py
@@ -19,7 +19,7 @@ import resources.lib.common.cookies as cookies
 import resources.lib.api.website as website
 import resources.lib.kodi.ui as ui
 from resources.lib.globals import g
-from resources.lib.services.nfsession.nfsession_requests import NFSessionRequests, BASE_URL
+from resources.lib.services.nfsession.nfsession_requests import NFSessionRequests
 from resources.lib.services.nfsession.nfsession_cookie import NFSessionCookie
 from resources.lib.api.exceptions import (LoginFailedError, LoginValidateError,
                                           MissingCredentialsError, InvalidMembershipStatusError)
@@ -77,8 +77,9 @@ class NFSessionAccess(NFSessionRequests, NFSessionCookie):
         """A hack way to full load requests module before making any other calls"""
         # The first call made with 'requests' module, can takes more than one second longer then
         # usual to elaborate (depend from device/os/connection), to camouflage this delay
-        # and make the add-on frontend faster this request is made when the service is started
-        self.session.head(url=BASE_URL)
+        # and make the add-on frontend faster this request is made when the service is started.
+        # Side note: authURL probably has a expiration time not knowing which one we are obliged to refresh session data
+        self.try_refresh_session_data()
 
     @common.addonsignals_return_call
     def login(self):

--- a/resources/lib/services/nfsession/nfsession_requests.py
+++ b/resources/lib/services/nfsession/nfsession_requests.py
@@ -95,12 +95,11 @@ class NFSessionRequests(NFSessionBase):
             data=data)
         common.debug('Request took {}s', time.clock() - start)
         common.debug('Request returned statuscode {}', response.status_code)
-        if response.status_code == 404 and not session_refreshed:
-            # It may happen that netflix updates the build_identifier version
-            # when you are watching a video or browsing the menu,
-            # this causes the api address to change, and return 'url not found' error
-            # So let's try updating the session data (just once)
-            common.warn('Try refresh session data to update build_identifier version')
+        if response.status_code in [404, 401] and not session_refreshed:
+            # 404 - It may happen when Netflix update the build_identifier version and causes the api address to change
+            # 401 - It may happen when authURL is not more valid (Unauthorized for url)
+            # So let's try refreshing the session data (just once)
+            common.warn('Try refresh session data due to {} http error', response.status_code)
             if self.try_refresh_session_data():
                 return self._request(method, component, True, **kwargs)
         response.raise_for_status()


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Regression caused by implementation to get profiles throught API
before session was always refreshed in the profile window because it was executed at same time when parsed reactContext

rif. https://github.com/CastagnaIT/plugin.video.netflix/issues/429
### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
