### PR TITLE
Fixes workarounds for apple ios/tvos restrictions

### DIFF
--- a/resources/lib/api/website.py
+++ b/resources/lib/api/website.py
@@ -240,48 +240,48 @@ def validate_login(react_context):
 
 def generate_esn(user_data):
     """Generate an ESN if on android or return the one from user_data"""
-    import subprocess
-    try:
-        manufacturer = subprocess.check_output(
-            ['/system/bin/getprop',
-             'ro.product.manufacturer']).decode('utf-8').strip(' \t\n\r')
-        if manufacturer:
-            model = subprocess.check_output(
+    if common.get_system_platform() == 'android':
+        import subprocess
+        try:
+            manufacturer = subprocess.check_output(
                 ['/system/bin/getprop',
-                 'ro.product.model']).decode('utf-8').strip(' \t\n\r')
-            product_characteristics = subprocess.check_output(
-                ['/system/bin/getprop',
-                 'ro.build.characteristics']).decode('utf-8').strip(' \t\n\r')
-            # Property ro.build.characteristics may also contain more then one value
-            has_product_characteristics_tv = any(
-                value.strip(' ') == 'tv' for value in product_characteristics.split(','))
-            # Netflix Ready Device Platform (NRDP)
-            nrdp_modelgroup = subprocess.check_output(
-                ['/system/bin/getprop',
-                 'ro.nrdp.modelgroup']).decode('utf-8').strip(' \t\n\r')
+                 'ro.product.manufacturer']).decode('utf-8').strip(' \t\n\r')
+            if manufacturer:
+                model = subprocess.check_output(
+                    ['/system/bin/getprop',
+                     'ro.product.model']).decode('utf-8').strip(' \t\n\r')
+                product_characteristics = subprocess.check_output(
+                    ['/system/bin/getprop',
+                     'ro.build.characteristics']).decode('utf-8').strip(' \t\n\r')
+                # Property ro.build.characteristics may also contain more then one value
+                has_product_characteristics_tv = any(
+                    value.strip(' ') == 'tv' for value in product_characteristics.split(','))
+                # Netflix Ready Device Platform (NRDP)
+                nrdp_modelgroup = subprocess.check_output(
+                    ['/system/bin/getprop',
+                     'ro.nrdp.modelgroup']).decode('utf-8').strip(' \t\n\r')
 
-            if has_product_characteristics_tv and \
-                    g.LOCAL_DB.get_value('drm_security_level', '', table=TABLE_SESSION) == 'L1':
-                esn = 'NFANDROID2-PRV-'
-                if nrdp_modelgroup:
-                    esn += nrdp_modelgroup + '-'
+                if has_product_characteristics_tv and \
+                        g.LOCAL_DB.get_value('drm_security_level', '', table=TABLE_SESSION) == 'L1':
+                    esn = 'NFANDROID2-PRV-'
+                    if nrdp_modelgroup:
+                        esn += nrdp_modelgroup + '-'
+                    else:
+                        esn += model.replace(' ', '').upper() + '-'
                 else:
-                    esn += model.replace(' ', '').upper() + '-'
-            else:
-                esn = 'NFANDROID1-PRV-'
-                esn += 'T-L3-'
+                    esn = 'NFANDROID1-PRV-'
+                    esn += 'T-L3-'
 
-            esn += '{:=<5.5}'.format(manufacturer.upper())
-            esn += model.replace(' ', '=').upper()
-            esn = sub(r'[^A-Za-z0-9=-]', '=', esn)
-            system_id = g.LOCAL_DB.get_value('drm_system_id', table=TABLE_SESSION)
-            if system_id:
-                esn += '-' + str(system_id) + '-'
-            common.debug('Android generated ESN: {}', esn)
-            return esn
-    except OSError:
-        pass
-
+                esn += '{:=<5.5}'.format(manufacturer.upper())
+                esn += model.replace(' ', '=').upper()
+                esn = sub(r'[^A-Za-z0-9=-]', '=', esn)
+                system_id = g.LOCAL_DB.get_value('drm_system_id', table=TABLE_SESSION)
+                if system_id:
+                    esn += '-' + str(system_id) + '-'
+                common.debug('Android generated ESN: {}', esn)
+                return esn
+        except OSError:
+            pass
     return user_data.get('esn', '')
 
 

--- a/resources/lib/common/uuid_device.py
+++ b/resources/lib/common/uuid_device.py
@@ -54,7 +54,9 @@ def _get_system_uuid():
         uuid_value = _get_android_uuid()
     elif system == 'linux':
         uuid_value = _get_linux_uuid()
-    elif system in ['osx', 'ios']:
+    elif system == 'osx':
+        # Due to OS restrictions on 'ios' and 'tvos' is not possible to use _get_macos_uuid()
+        # See python limits in the wiki development page
         uuid_value = _get_macos_uuid()
     if not uuid_value:
         debug('It is not possible to get a system UUID creating a new UUID')
@@ -120,8 +122,7 @@ def _get_android_uuid():
                     'persist.sys.timezone', 'persist.sys.locale', 'net.hostname']
         # Warning net.hostname property starting from android 10 is deprecated return empty
         proc = subprocess.Popen(['/system/bin/getprop'], stdout=subprocess.PIPE)
-        output_data = proc.stdout.read().decode('utf-8')
-        proc.stdout.close()
+        output_data = proc.communicate()[0].decode('utf-8')
         list_values = output_data.splitlines()
         for value in list_values:
             value_splitted = re.sub(r'\[|\]|\s', '', value).split(':')
@@ -140,8 +141,7 @@ def _get_macos_uuid():
         proc = subprocess.Popen(
             ['/usr/sbin/system_profiler', 'SPHardwareDataType', '-detaillevel', 'full', '-xml'],
             stdout=subprocess.PIPE)
-        output_data = proc.stdout.read().decode('utf-8')
-        proc.stdout.close()
+        output_data = proc.communicate()[0].decode('utf-8')
         if output_data:
             sp_dict_values = _parse_osx_xml_plist_data(output_data)
     except Exception as exc:
@@ -185,5 +185,10 @@ def _get_fake_uuid(with_hostname=True):
     import platform
     list_values = [xbmc.getInfoLabel('System.Memory(total)')]
     if with_hostname:
-        list_values.append(platform.node())
+        try:
+            list_values.append(platform.node())
+        except Exception:  # pylint: disable=broad-except
+            # Due to OS restrictions on 'ios' and 'tvos' an error happen
+            # See python limits in the wiki development page
+            pass
     return '_'.join(list_values)

--- a/resources/lib/kodi/ui/xmldialogs.py
+++ b/resources/lib/kodi/ui/xmldialogs.py
@@ -11,12 +11,11 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import time
-from platform import machine
 
 import xbmc
 import xbmcgui
 
-from resources.lib.common import run_threaded
+from resources.lib.common import run_threaded, get_machine
 from resources.lib.globals import g
 from resources.lib.kodi.ui.dialogs import (show_ok_dialog, show_error_info)
 
@@ -31,8 +30,6 @@ XBFONT_CENTER_X = 0x00000002
 XBFONT_CENTER_Y = 0x00000004
 XBFONT_TRUNCATED = 0x00000008
 XBFONT_JUSTIFY = 0x00000010
-
-OS_MACHINE = machine()
 
 CMD_CLOSE_DIALOG_BY_NOOP = 'AlarmClock(closedialog,Action(noop),{},silent)'
 
@@ -79,10 +76,13 @@ class Skip(xbmcgui.WindowXMLDialog):
                                    ACTION_NAV_BACK,
                                    ACTION_NOOP]
 
-        if OS_MACHINE[0:5] == 'armv7':
+        if get_machine()[0:5] == 'armv7':
             xbmcgui.WindowXMLDialog.__init__(self)
         else:
-            xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            try:
+                xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            except Exception:  # pylint: disable=broad-except
+                xbmcgui.WindowXMLDialog.__init__(self)
 
     def onInit(self):
         self.getControl(6012).setLabel(self.label)
@@ -116,10 +116,13 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
         self.action_exitkeys_id = [ACTION_PREVIOUS_MENU,
                                    ACTION_PLAYER_STOP,
                                    ACTION_NAV_BACK]
-        if OS_MACHINE[0:5] == 'armv7':
+        if get_machine()[0:5] == 'armv7':
             xbmcgui.WindowXMLDialog.__init__(self)
         else:
-            xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            try:
+                xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            except Exception:  # pylint: disable=broad-except
+                xbmcgui.WindowXMLDialog.__init__(self)
 
     def onInit(self):
         self._generate_levels_labels()
@@ -224,10 +227,13 @@ class RatingThumb(xbmcgui.WindowXMLDialog):
         self.action_exitkeys_id = [ACTION_PREVIOUS_MENU,
                                    ACTION_PLAYER_STOP,
                                    ACTION_NAV_BACK]
-        if OS_MACHINE[0:5] == 'armv7':
+        if get_machine()[0:5] == 'armv7':
             xbmcgui.WindowXMLDialog.__init__(self)
         else:
-            xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            try:
+                xbmcgui.WindowXMLDialog.__init__(self, *args, **kwargs)
+            except Exception:  # pylint: disable=broad-except
+                xbmcgui.WindowXMLDialog.__init__(self)
 
     def onInit(self):
         self.getControl(10000).setLabel(self.title)

--- a/resources/lib/services/msl/request_builder.py
+++ b/resources/lib/services/msl/request_builder.py
@@ -22,7 +22,9 @@ import resources.lib.common as common
 try:
     SDKVERSION = int(subprocess.check_output(
         ['/system/bin/getprop', 'ro.build.version.sdk']))
-except (OSError, subprocess.CalledProcessError):
+except (OSError, subprocess.CalledProcessError, AttributeError):
+    # Due to OS restrictions on 'ios' and 'tvos' this give AttributeError
+    # See python limits in the wiki development page
     SDKVERSION = 0
 
 if SDKVERSION >= 18:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Now the addon also works on iOS but is needed finding a solution for get the widevine library

The problem is that apple imposes restrictions on Python compatibility that causes problems on some Python features

I made a list here, between information obtained from the tests and on the net:
https://github.com/CastagnaIT/plugin.video.netflix/wiki/Development-docs#apple-ios-tvos-limits-python-compatibility



### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
