### PR TITLE
Fixes for try to update watched status to netflix

### DIFF
--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -102,13 +102,9 @@ def root_lists():
                     ART_PARTIAL_PATHS)))
 
 
-def update_lolomo_context(context_name, video_id=None):
+def update_lolomo_context(context_name):
     """Update the lolomo list by context"""
     # Should update the context list but it doesn't, what is missing?
-    # The remaining requests made on the website that are missing here are of logging type,
-    # it seems strange that they use log data to finish the operations are almost impossible to reproduce here:
-    # pbo_logblobs /logblob
-    # personalization/cl2
 
     lolomo_data = common.make_call('path_request', [["lolomo", [context_name], ['context', 'id', 'index']]])
     # Note: lolomo root seem differs according to the profile in use
@@ -140,12 +136,24 @@ def update_lolomo_context(context_name, video_id=None):
     response = common.make_http_call('callpath_request', callargs)
     common.debug('refreshListByContext response: {}', response)
 
+
+def update_videoid_bookmark(video_id):
+    """Update the videoid bookmark position"""
+    # You can check if this function works through the official android app
+    # by checking if the status bar watched of the video will be updated
     callargs = {
         'callpaths': [['refreshVideoCurrentPositions']],
-        'params': ['[' + video_id + ']', ''],
+        'params': ['[' + video_id + ']', '[]'],
     }
-    response = common.make_http_call('callpath_request', callargs)
-    common.debug('refreshVideoCurrentPositions response: {}', response)
+    try:
+        response = common.make_http_call('callpath_request', callargs)
+        common.debug('refreshVideoCurrentPositions response: {}', response)
+    except Exception:  # pylint: disable=broad-except
+        # I do not know the reason yet, but sometimes continues to return error 401,
+        # making it impossible to update the bookmark position
+        ui.show_notification(title=common.get_local_string(30105),
+                             msg='An error prevented the update the status watched on netflix',
+                             time=10000)
 
 
 @cache.cache_output(cache.CACHE_COMMON, identify_from_kwarg_name='list_type')

--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -75,8 +75,8 @@ def update_profiles_data():
 
 def activate_profile(profile_id):
     """Activate the profile with the given ID"""
-    if common.make_call('activate_profile', profile_id):
-        g.CACHE.invalidate()
+    common.make_call('activate_profile', profile_id)
+    g.CACHE.invalidate()
 
 
 @common.time_execution(immediate=False)

--- a/resources/lib/api/shakti.py
+++ b/resources/lib/api/shakti.py
@@ -305,7 +305,7 @@ def episodes(videoid, videoid_value, perpetual_range_start=None):  # pylint: dis
 
 
 @common.time_execution(immediate=False)
-@cache.cache_output(cache.CACHE_SUPPLEMENTAL, save_call_data=True)
+@cache.cache_output(cache.CACHE_SUPPLEMENTAL)
 def supplemental_video_list(videoid, supplemental_type):
     """Retrieve a supplemental video list"""
     if videoid.mediatype != common.VideoId.SHOW and videoid.mediatype != common.VideoId.MOVIE:

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -358,6 +358,7 @@ def _set_progress_status(list_item, video_data, infos):
     # Check from db if user has manually changed the watched status
     profile_guid = g.LOCAL_DB.get_active_profile_guid()
     override_is_watched = g.SHARED_DB.get_watched_status(profile_guid, video_id, None, bool)
+    resume_time = 0
 
     if override_is_watched is None:
         # NOTE shakti 'watched' tag value:
@@ -374,10 +375,11 @@ def _set_progress_status(list_item, video_data, infos):
         # NOTE shakti 'bookmarkPosition' tag when it is not set have -1 value
         playcount = '1' if video_data['bookmarkPosition'] >= watched_threshold else '0'
         if playcount == '0' and video_data['bookmarkPosition'] > 0:
-            list_item.setProperty('ResumeTime', str(video_data['bookmarkPosition']))
-            list_item.setProperty('TotalTime', str(video_data['runtime']))
+            resume_time = video_data['bookmarkPosition']
     else:
         playcount = '1' if override_is_watched else '0'
     # We have to set playcount with setInfo(), because the setProperty('PlayCount', ) have a bug
     # when a item is already watched and you force to set again watched, the override do not work
     infos['PlayCount'] = playcount
+    list_item.setProperty('TotalTime', str(video_data['runtime']))
+    list_item.setProperty('ResumeTime', str(resume_time))

--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -154,27 +154,24 @@ class AddonActionExecutor(object):
         # Open root page
         xbmc.executebuiltin('Container.Update({},replace)'.format(url))  # replace=reset history
 
-    def change_watched_status(self, pathitems=None):  # pylint: disable=unused-argument
-        from os import path
-        videoid = path.basename(path.normpath(xbmc.getInfoLabel('ListItem.Path')))
-        if videoid.isdigit():
-            # Todo: how get resumetime/playcount of selected item for calculate current watched status?
+    @common.inject_video_id(path_offset=1)
+    def change_watched_status(self, videoid):
+        """Change the watched status locally"""
+        # Todo: how get resumetime/playcount of selected item for calculate current watched status?
 
-            profile_guid = g.LOCAL_DB.get_active_profile_guid()
-            current_value = g.SHARED_DB.get_watched_status(profile_guid, videoid, None, bool)
-            if current_value:
-                txt_index = 1
-                g.SHARED_DB.set_watched_status(profile_guid, videoid, False)
-            elif current_value is not None and not current_value:
-                txt_index = 2
-                g.SHARED_DB.delete_watched_status(profile_guid, videoid)
-            else:
-                txt_index = 0
-                g.SHARED_DB.set_watched_status(profile_guid, videoid, True)
-            ui.show_notification(common.get_local_string(30237).split('|')[txt_index])
-            common.refresh_container()
+        profile_guid = g.LOCAL_DB.get_active_profile_guid()
+        current_value = g.SHARED_DB.get_watched_status(profile_guid, videoid.value, None, bool)
+        if current_value:
+            txt_index = 1
+            g.SHARED_DB.set_watched_status(profile_guid, videoid.value, False)
+        elif current_value is not None and not current_value:
+            txt_index = 2
+            g.SHARED_DB.delete_watched_status(profile_guid, videoid.value)
         else:
-            common.error('No video id found in the current path: {}', path)
+            txt_index = 0
+            g.SHARED_DB.set_watched_status(profile_guid, videoid.value, True)
+        ui.show_notification(common.get_local_string(30237).split('|')[txt_index])
+        common.refresh_container()
 
     def configuration_wizard(self, pathitems=None):  # pylint: disable=unused-argument
         """Run the add-on configuration wizard"""

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -70,7 +70,7 @@ def play(videoid):
         return
 
     list_item = get_inputstream_listitem(videoid)
-    infos, art = infolabels.add_info_for_playback(videoid, list_item, is_up_next_enabled)
+    infos, art = infolabels.add_info_for_playback(videoid, list_item, is_up_next_enabled, skip_set_progress_status=True)
 
     resume_position = {}
     event_data = {}

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -202,7 +202,7 @@ class EventsHandler(threading.Thread):
 
         params = {
             'event': event_type,
-            'xid': g.LOCAL_DB.get_value('xid', table=TABLE_SESSION),
+            'xid': previous_data.get('xid', g.LOCAL_DB.get_value('xid', table=TABLE_SESSION)),
             'position': player_state['elapsed_seconds'] * 1000,  # Video time elapsed
             'clientTime': timestamp,
             'sessionStartTime': previous_data.get('sessionStartTime', timestamp),

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -124,7 +124,7 @@ class EventsHandler(threading.Thread):
                 common.error('EVENT [{}] - The request has failed: {}', event, exc)
         if event.event_type == EVENT_STOP:
             self.clear_queue()
-            # api.update_lolomo_context('continueWatching')
+            api.update_lolomo_context('continueWatching')
             api.update_videoid_bookmark(event.get_video_id())
         # Below commented lines: let future requests continue to be sent, unstable connections like wi-fi cause problems
         # if not event.is_response_success():
@@ -184,8 +184,8 @@ class EventsHandler(threading.Thread):
 
         # Context location values can be easily viewed from tag data-ui-tracking-context
         # of a preview box in website html
-        play_ctx_location = 'WATCHNOW'  # We currently leave a fixed value, we leave support for future changes
-        # play_ctx_location = 'MyListAsGallery' if event_data['is_in_mylist'] else 'browseTitles'
+        # play_ctx_location = 'WATCHNOW'
+        play_ctx_location = 'MyListAsGallery' if event_data['is_in_mylist'] else 'browseTitles'
 
         # To now it is not mandatory, we leave support for future changes
         # if event_data['is_played_by_library']:
@@ -218,7 +218,8 @@ class EventsHandler(threading.Thread):
                 'preferUnletterboxed': True,  # Should be set equal to the manifest request
                 'uiplaycontext': {
                     # 'list_id': list_id,  # not mandatory
-                    # 'lolomo_id': g.LOCAL_DB.get_value('lolomo_root_id', '', TABLE_SESSION),  # not mandatory
+                    # Add 'lolomo_id' seems to prevent failure of the 'refreshListByContext' request
+                    'lolomo_id': g.LOCAL_DB.get_value('lolomo_root_id', '', TABLE_SESSION),  # not mandatory
                     'location': play_ctx_location,
                     'rank': 0,  # Perhaps this is a reference of cdn rank used in the manifest? (we use always 0)
                     'request_id': event_data['request_id'],

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -126,10 +126,11 @@ class EventsHandler(threading.Thread):
             self.clear_queue()
             # api.update_lolomo_context('continueWatching')
             api.update_videoid_bookmark(event.get_video_id())
-        if not event.is_response_success():
+        # Below commented lines: let future requests continue to be sent, unstable connections like wi-fi cause problems
+        # if not event.is_response_success():
             # The event request is unsuccessful then there is some problem,
             # no longer make any future requests from this event id
-            return False
+        #     return False
         return True
 
     def callback_event_video_queue(self, data=None):

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -20,7 +20,7 @@ except ImportError:  # Python 3
 
 import xbmc
 
-# import resources.lib.api.shakti as api
+import resources.lib.api.shakti as api
 import resources.lib.cache as cache
 from resources.lib import common
 from resources.lib.database.db_utils import TABLE_SESSION
@@ -124,7 +124,8 @@ class EventsHandler(threading.Thread):
                 common.error('EVENT [{}] - The request has failed: {}', event, exc)
         if event.event_type == EVENT_STOP:
             self.clear_queue()
-            # api.update_lolomo_context('continueWatching', video_id=event.get_video_id())
+            # api.update_lolomo_context('continueWatching')
+            api.update_videoid_bookmark(event.get_video_id())
         if not event.is_response_success():
             # The event request is unsuccessful then there is some problem,
             # no longer make any future requests from this event id

--- a/resources/lib/services/nfsession/nfsession.py
+++ b/resources/lib/services/nfsession/nfsession.py
@@ -9,7 +9,6 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 
-import time
 import json
 import requests
 
@@ -79,25 +78,21 @@ class NetflixSession(NFSessionAccess):
     @common.time_execution(immediate=True)
     def activate_profile(self, guid):
         """Set the profile identified by guid as active"""
-        common.info('Activating profile {}', guid)
-        if guid == g.LOCAL_DB.get_active_profile_guid():
-            common.debug('Profile {} is already active', guid)
-            return False
-        # When switch profile is performed the authURL change
+        common.debug('Switching to profile {}', guid)
         response = self._get('switch_profile', params={'tkn': guid})
         react_context = website.extract_json(response, 'reactContext')
         self.auth_url = website.extract_api_data(react_context)['auth_url']
 
-        self._get(component='activate_profile',
-                  req_type='api',
-                  params={'switchProfileGuid': guid,
-                          '_': int(time.time()),
-                          'authURL': self.auth_url})
+        # if guid != g.LOCAL_DB.get_active_profile_guid():
+        #     common.info('Activating profile {}', guid)
+        #     self._get(component='activate_profile',
+        #               req_type='api',
+        #               params={'switchProfileGuid': guid,
+        #                       '_': int(time.time()),
+        #                       'authURL': self.auth_url})
 
         g.LOCAL_DB.switch_active_profile(guid)
         self.update_session_data()
-        common.debug('Successfully activated profile {}', guid)
-        return True
 
     @common.addonsignals_return_call
     @needs_login
@@ -114,11 +109,11 @@ class NetflixSession(NFSessionAccess):
         # Current profile active
         current_profile_guid = g.LOCAL_DB.get_active_profile_guid()
         # Switch profile (only if necessary) in order to get My List videos
-        is_profile_switched = self.activate_profile(mylist_profile_guid)
+        self.activate_profile(mylist_profile_guid)
         # Get the My List data
         path_response = self._perpetual_path_request(paths, length_params, perpetual_range_start,
                                                      no_limit_req)
-        if is_profile_switched:
+        if mylist_profile_guid != current_profile_guid:
             # Reactive again the previous profile
             self.activate_profile(current_profile_guid)
         return path_response

--- a/resources/lib/services/nfsession/nfsession.py
+++ b/resources/lib/services/nfsession/nfsession.py
@@ -16,6 +16,7 @@ import requests
 import resources.lib.common as common
 import resources.lib.api.paths as apipaths
 import resources.lib.api.website as website
+from resources.lib.database.db_utils import TABLE_SESSION
 from resources.lib.globals import g
 from resources.lib.services.nfsession.nfsession_access import NFSessionAccess
 from resources.lib.services.nfsession.nfsession_base import needs_login
@@ -212,7 +213,12 @@ class NetflixSession(NFSessionAccess):
             'drmSystem': 'widevine',
             # 'falcor_server': '0.1.0',
             'withSize': 'false',
-            'materialize': 'false'
+            'materialize': 'false',
+            'routeAPIRequestsThroughFTL': 'false',
+            'isVolatileBillboardsEnabled': 'true',
+            'isWatchlistEnabled': 'false',
+            'original_path': '/shakti/{}/pathEvaluator'.format(
+                g.LOCAL_DB.get_value('build_identifier', '', TABLE_SESSION))
         }
         data = 'path=' + '&path='.join(json.dumps(path) for path in paths)
         data += '&authURL=' + self.auth_url
@@ -251,7 +257,9 @@ class NetflixSession(NFSessionAccess):
             'materialize': 'true',
             'routeAPIRequestsThroughFTL': 'false',
             'isVolatileBillboardsEnabled': 'true',
-            'isWatchlistEnabled': 'false'
+            'isWatchlistEnabled': 'false',
+            'original_path': '/shakti/{}/pathEvaluator'.format(
+                g.LOCAL_DB.get_value('build_identifier', '', TABLE_SESSION))
         }
         data = 'callPath=' + '&callPath='.join(json.dumps(callpath) for callpath in callpaths)
         if params:

--- a/resources/lib/services/nfsession/nfsession_base.py
+++ b/resources/lib/services/nfsession/nfsession_base.py
@@ -80,8 +80,10 @@ class NFSessionBase(object):
     def set_session_header_data(self):
         try:
             # When the addon is installed from scratch there is no profiles in the database
-            self.session.headers.update(
-                {'x-netflix.request.client.user.guid': g.LOCAL_DB.get_active_profile_guid()})
+            self.session.headers.update({
+                'x-netflix.nq.stack': 'prod',
+                'x-netflix.request.client.user.guid': g.LOCAL_DB.get_active_profile_guid()
+            })
         except ProfilesMissing:
             pass
 

--- a/resources/lib/services/playback/progress_manager.py
+++ b/resources/lib/services/playback/progress_manager.py
@@ -85,6 +85,7 @@ class ProgressManager(PlaybackActionManager):
             return
         self.tick_elapsed = 0
         _send_event(EVENT_ENGAGE, self.event_data, player_state)
+        self._save_resume_time(player_state['elapsed_seconds'])
 
     def _on_playback_stopped(self):
         if not self.is_event_start_sent or self.lock_events:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
I'm trying to solve the last two problems
- Watched progress on android which is not displayed ✔
- Continue watching list not updated [?]

I solved the problem to update bookmarks in order to fix android watched status,
but sometimes the request returns error `401 Client Error: Unauthorized for url`
it is not really an authUrl problem, but it is associated with some other problem,
that i still don't understand

Update:
I have not had this error in the last few days,
i hope it's resolved, but i don't believe it too much...

Unsersolved:
"Resume from" context menu randomly not work, seem more a kodi bug,
at the moment i don't know what to do

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
