### PR TITLE
make time.clock() work on Python 3.8

### DIFF
--- a/resources/lib/common/logging.py
+++ b/resources/lib/common/logging.py
@@ -12,8 +12,8 @@ from __future__ import absolute_import, division, unicode_literals
 from functools import wraps
 from sys import version_info
 
-import xbmc
 from future.utils import iteritems
+import xbmc
 from resources.lib.globals import g
 
 if version_info.major == 3 and version_info.minor >= 3:

--- a/resources/lib/common/logging.py
+++ b/resources/lib/common/logging.py
@@ -8,8 +8,14 @@
     See LICENSES/MIT.md for more information.
 """
 from __future__ import absolute_import, division, unicode_literals
+
 from functools import wraps
 from sys import version_info
+
+import xbmc
+from future.utils import iteritems
+from resources.lib.globals import g
+
 if version_info.major == 3 and version_info.minor >= 3:
     from time import perf_counter
 
@@ -17,11 +23,6 @@ if version_info.major == 3 and version_info.minor >= 3:
         return perf_counter() * 1.0e-6
 else:
     from time import clock
-from future.utils import iteritems
-
-import xbmc
-
-from resources.lib.globals import g
 
 __LOG_LEVEL__ = None
 

--- a/resources/lib/common/logging.py
+++ b/resources/lib/common/logging.py
@@ -9,8 +9,14 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 from functools import wraps
-from time import clock
+from sys import version_info
+if version_info.major == 3 and version_info.minor >= 3:
+    from time import perf_counter
 
+    def clock():
+        return perf_counter() * 1.0e-6
+else:
+    from time import clock
 from future.utils import iteritems
 
 import xbmc

--- a/resources/lib/common/logging.py
+++ b/resources/lib/common/logging.py
@@ -10,18 +10,17 @@
 from __future__ import absolute_import, division, unicode_literals
 
 from functools import wraps
-from sys import version_info
 
 from future.utils import iteritems
 import xbmc
 from resources.lib.globals import g
 
-if version_info.major == 3 and version_info.minor >= 3:
+try:
     from time import perf_counter
 
     def clock():
         return perf_counter() * 1.0e-6
-else:
+except ImportError:
     from time import clock
 
 __LOG_LEVEL__ = None

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -13,15 +13,8 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import json
 import re
-from sys import version_info
-if version_info.major == 3 and version_info.minor >= 3:
-    from time import perf_counter, time
-
-    def clock():
-        return perf_counter() * 1.0e-6
-else:
-    from time import clock, time
 import zlib
+from sys import version_info
 
 import requests
 
@@ -29,8 +22,18 @@ import resources.lib.common as common
 from resources.lib.globals import g
 from resources.lib.services.msl.exceptions import MSLError
 from resources.lib.services.msl.msl_request_builder import MSLRequestBuilder
-from resources.lib.services.msl.msl_utils import (display_error_info, generate_logblobs_params, EVENT_BIND, ENDPOINTS,
-                                                  MSL_DATA_FILENAME)
+from resources.lib.services.msl.msl_utils import (ENDPOINTS, EVENT_BIND,
+                                                  MSL_DATA_FILENAME,
+                                                  display_error_info,
+                                                  generate_logblobs_params)
+
+if version_info.major == 3 and version_info.minor >= 3:
+    from time import perf_counter, time
+
+    def clock():
+        return perf_counter() * 1.0e-6
+else:
+    from time import clock, time
 
 try:  # Python 2
     from urllib import urlencode

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import json
 import re
-import sys
 import zlib
 from time import time
 
@@ -28,28 +27,10 @@ from resources.lib.services.msl.msl_utils import (ENDPOINTS, EVENT_BIND,
                                                   display_error_info,
                                                   generate_logblobs_params)
 
-# time.clock() was deprecated in Python 3.3 and removed in Python 3.8
-try:
-    # Python 3.8 or later
-    from time import perf_counter as clock
-except ImportError:
-    # Python 3.2 or earlier
-    from time import clock
-
 try:  # Python 2
     from urllib import urlencode
 except ImportError:  # Python 3
     from urllib.parse import urlencode
-
-
-# time.perf_counter() returns time in [us]
-if hasattr(sys.modules['time'], 'perf_counter'):
-    CLOCK_TO_SECONDS = 1.e-6
-# time.clock() returns time in [s]
-elif hasattr(sys.modules['time'], 'clock'):
-    CLOCK_TO_SECONDS = 1.0
-else:
-    CLOCK_TO_SECONDS = 1.0
 
 
 class MSLRequests(MSLRequestBuilder):
@@ -198,9 +179,9 @@ class MSLRequests(MSLRequestBuilder):
     def _post(self, endpoint, request_data):
         """Execute a post request"""
         common.debug('Executing POST request to {}', endpoint)
-        start = clock()
+        start = common.logging.clock_s()
         response = self.session.post(endpoint, request_data)
-        common.debug('Request took {}s', (clock() - start) * CLOCK_TO_SECONDS)
+        common.debug('Request took {}s', common.logging.clock_s() - start)
         common.debug('Request returned response with status {}', response.status_code)
         response.raise_for_status()
         return response

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -13,7 +13,9 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import json
 import re
+import sys
 import zlib
+from time import time
 
 import requests
 
@@ -26,18 +28,28 @@ from resources.lib.services.msl.msl_utils import (ENDPOINTS, EVENT_BIND,
                                                   display_error_info,
                                                   generate_logblobs_params)
 
+# time.clock() was deprecated in Python 3.3 and removed in Python 3.8
 try:
-    from time import perf_counter, time
-
-    def clock():
-        return perf_counter() * 1.0e-6
+    # Python 3.8 or later
+    from time import perf_counter as clock
 except ImportError:
-    from time import clock, time
+    # Python 3.2 or earlier
+    from time import clock
 
 try:  # Python 2
     from urllib import urlencode
 except ImportError:  # Python 3
     from urllib.parse import urlencode
+
+
+# time.perf_counter() returns time in [us]
+if hasattr(sys.modules['time'], 'perf_counter'):
+    CLOCK_TO_SECONDS = 1.e-6
+# time.clock() returns time in [s]
+elif hasattr(sys.modules['time'], 'clock'):
+    CLOCK_TO_SECONDS = 1.0
+else:
+    CLOCK_TO_SECONDS = 1.0
 
 
 class MSLRequests(MSLRequestBuilder):
@@ -188,7 +200,7 @@ class MSLRequests(MSLRequestBuilder):
         common.debug('Executing POST request to {}', endpoint)
         start = clock()
         response = self.session.post(endpoint, request_data)
-        common.debug('Request took {}s', clock() - start)
+        common.debug('Request took {}s', (clock() - start) * CLOCK_TO_SECONDS)
         common.debug('Request returned response with status {}', response.status_code)
         response.raise_for_status()
         return response

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -13,7 +13,14 @@ from __future__ import absolute_import, division, unicode_literals
 import base64
 import json
 import re
-import time
+from sys import version_info
+if version_info.major == 3 and version_info.minor >= 3:
+    from time import perf_counter, time
+
+    def clock():
+        return perf_counter() * 1.0e-6
+else:
+    from time import clock, time
 import zlib
 
 import requests
@@ -102,7 +109,7 @@ class MSLRequests(MSLRequestBuilder):
     def _check_mastertoken_validity(self):
         """Return the mastertoken validity and executes a new key handshake when necessary"""
         if self.crypto.mastertoken:
-            time_now = time.time()
+            time_now = time()
             renewable = self.crypto.renewal_window < time_now
             expired = self.crypto.expiration <= time_now
         else:
@@ -177,9 +184,9 @@ class MSLRequests(MSLRequestBuilder):
     def _post(self, endpoint, request_data):
         """Execute a post request"""
         common.debug('Executing POST request to {}', endpoint)
-        start = time.clock()
+        start = clock()
         response = self.session.post(endpoint, request_data)
-        common.debug('Request took {}s', time.clock() - start)
+        common.debug('Request took {}s', clock() - start)
         common.debug('Request returned response with status {}', response.status_code)
         response.raise_for_status()
         return response

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -27,12 +27,12 @@ from resources.lib.services.msl.msl_utils import (ENDPOINTS, EVENT_BIND,
                                                   display_error_info,
                                                   generate_logblobs_params)
 
-if version_info.major == 3 and version_info.minor >= 3:
+try:
     from time import perf_counter, time
 
     def clock():
         return perf_counter() * 1.0e-6
-else:
+except ImportError:
     from time import clock, time
 
 try:  # Python 2

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -14,7 +14,6 @@ import base64
 import json
 import re
 import zlib
-from sys import version_info
 
 import requests
 

--- a/resources/lib/services/nfsession/nfsession_requests.py
+++ b/resources/lib/services/nfsession/nfsession_requests.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import json
-import sys
 
 import requests
 
@@ -27,23 +26,6 @@ from resources.lib.globals import g
 from resources.lib.services.nfsession.nfsession_base import (NFSessionBase,
                                                              needs_login)
 
-# time.clock() was deprecated in Python 3.3 and removed in Python 3.8
-try:
-    # Python 3.8 or later
-    from time import perf_counter as clock
-except ImportError:
-    # Python 3.2 or earlier
-    from time import clock
-
-
-# time.perf_counter() returns time in [us]
-if hasattr(sys.modules['time'], 'perf_counter'):
-    CLOCK_TO_SECONDS = 1.e-6
-# time.clock() returns time in [s]
-elif hasattr(sys.modules['time'], 'clock'):
-    CLOCK_TO_SECONDS = 1.0
-else:
-    CLOCK_TO_SECONDS = 1.0
 
 
 BASE_URL = 'https://www.netflix.com'
@@ -111,14 +93,14 @@ class NFSessionRequests(NFSessionBase):
                      verb='GET' if method == self.session.get else 'POST', url=url)
         data, headers, params = self._prepare_request_properties(component,
                                                                  kwargs)
-        start = clock()
+        start = common.logging.clock_s()
         response = method(
             url=url,
             verify=self.verify_ssl,
             headers=headers,
             params=params,
             data=data)
-        common.debug('Request took {}s', (clock() - start) * CLOCK_TO_SECONDS)
+        common.debug('Request took {}s', common.logging.clock_s() - start)
         common.debug('Request returned statuscode {}', response.status_code)
         if response.status_code in [404, 401] and not session_refreshed:
             # 404 - It may happen when Netflix update the build_identifier version and causes the api address to change

--- a/resources/lib/services/nfsession/nfsession_requests.py
+++ b/resources/lib/services/nfsession/nfsession_requests.py
@@ -10,7 +10,23 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 
+import json
 from sys import version_info
+
+import requests
+
+import resources.lib.api.website as website
+import resources.lib.common as common
+from resources.lib.api.exceptions import (APIError,
+                                          InvalidMembershipStatusAnonymous,
+                                          InvalidMembershipStatusError,
+                                          LoginValidateErrorIncorrectPassword,
+                                          WebsiteParsingError)
+from resources.lib.database.db_utils import TABLE_SESSION
+from resources.lib.globals import g
+from resources.lib.services.nfsession.nfsession_base import (NFSessionBase,
+                                                             needs_login)
+
 if version_info.major == 3 and version_info.minor >= 3:
     from time import perf_counter
 
@@ -18,17 +34,6 @@ if version_info.major == 3 and version_info.minor >= 3:
         return perf_counter() * 1.0e-6
 else:
     from time import clock
-import json
-import requests
-
-import resources.lib.common as common
-import resources.lib.api.website as website
-from resources.lib.globals import g
-from resources.lib.services.nfsession.nfsession_base import NFSessionBase, needs_login
-from resources.lib.database.db_utils import TABLE_SESSION
-from resources.lib.api.exceptions import (APIError, WebsiteParsingError,
-                                          InvalidMembershipStatusError, InvalidMembershipStatusAnonymous,
-                                          LoginValidateErrorIncorrectPassword)
 
 BASE_URL = 'https://www.netflix.com'
 """str: Secure Netflix url"""

--- a/resources/lib/services/nfsession/nfsession_requests.py
+++ b/resources/lib/services/nfsession/nfsession_requests.py
@@ -10,7 +10,14 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 
-import time
+from sys import version_info
+if version_info.major == 3 and version_info.minor >= 3:
+    from time import perf_counter
+
+    def clock():
+        return perf_counter() * 1.0e-6
+else:
+    from time import clock
 import json
 import requests
 
@@ -88,14 +95,14 @@ class NFSessionRequests(NFSessionBase):
                      verb='GET' if method == self.session.get else 'POST', url=url)
         data, headers, params = self._prepare_request_properties(component,
                                                                  kwargs)
-        start = time.clock()
+        start = clock()
         response = method(
             url=url,
             verify=self.verify_ssl,
             headers=headers,
             params=params,
             data=data)
-        common.debug('Request took {}s', time.clock() - start)
+        common.debug('Request took {}s', clock() - start)
         common.debug('Request returned statuscode {}', response.status_code)
         if response.status_code in [404, 401] and not session_refreshed:
             # 404 - It may happen when Netflix update the build_identifier version and causes the api address to change

--- a/resources/lib/services/nfsession/nfsession_requests.py
+++ b/resources/lib/services/nfsession/nfsession_requests.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import json
-from sys import version_info
 
 import requests
 
@@ -27,12 +26,12 @@ from resources.lib.globals import g
 from resources.lib.services.nfsession.nfsession_base import (NFSessionBase,
                                                              needs_login)
 
-if version_info.major == 3 and version_info.minor >= 3:
+try:
     from time import perf_counter
 
     def clock():
         return perf_counter() * 1.0e-6
-else:
+except ImportError:
     from time import clock
 
 BASE_URL = 'https://www.netflix.com'


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [ ] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
`time.clock()` was deprecated in Python 3.3 and removed in Python 3.8, breaking plugin on some Linux distributions, e.g., Fedora 32.

Instead try to use `time.perf_counter()` first.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
