### PR TITLE
Implemented numeric mask input

### DIFF
--- a/resources/lib/kodi/ui/dialogs.py
+++ b/resources/lib/kodi/ui/dialogs.py
@@ -69,6 +69,8 @@ def ask_for_pin(message):
     args = {'heading': message,
             'type': 0,
             'defaultt': ''}
+    if not g.KODI_VERSION.is_major_ver('18'):  # Kodi => 19.x support mask input
+        args['bHiddenInput'] = True
     return xbmcgui.Dialog().numeric(**args) or None
 
 

--- a/tests/xbmcgui.py
+++ b/tests/xbmcgui.py
@@ -136,7 +136,8 @@ class Dialog:
         return 'Foobar'
 
     @staticmethod
-    def numeric(type, heading, defaultt=''):  # pylint: disable=redefined-builtin
+    # def numeric(type, heading, defaultt=''):  # Kodi 18
+    def numeric(type, heading, defaultt='', bHiddenInput=False):  # pylint: disable=redefined-builtin
         """A stub implementation for the xbmcgui Dialog class numeric() method"""
         return
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Kodi 19 now support numeric mask input
so we can use it for the PIN input

It depend from https://github.com/xbmc/xbmc/pull/17661

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
