### PR TITLE
fix CacheMiss exception in StreamContinuityManager

### DIFF
--- a/resources/lib/services/playback/stream_continuity.py
+++ b/resources/lib/services/playback/stream_continuity.py
@@ -44,6 +44,7 @@ class StreamContinuityManager(PlaybackActionManager):
     def __init__(self):  # pylint: disable=super-on-old-class
         super(StreamContinuityManager, self).__init__()
         self.current_videoid = None
+        self.videoid = None
         self.current_streams = {}
         self.sc_settings = {}
         self.player = xbmc.Player()
@@ -57,6 +58,7 @@ class StreamContinuityManager(PlaybackActionManager):
         if videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
             self.enabled = False
             return
+        self.videoid = videoid
         self.current_videoid = videoid \
             if videoid.mediatype == common.VideoId.MOVIE \
             else videoid.derive_parent(0)
@@ -246,7 +248,7 @@ class StreamContinuityManager(PlaybackActionManager):
             # --- ONLY FOR KODI VERSION 18 ---
             # NOTE: With Kodi 18 it is not possible to read the properties of the streams
             # so the only possible way is to read the data from the manifest file
-            cache_identifier = g.get_esn() + '_' + self.current_videoid.value
+            cache_identifier = g.get_esn() + '_' + self.videoid.value
             manifest_data = g.CACHE.get(CACHE_MANIFESTS, cache_identifier)
             common.fix_locale_languages(manifest_data['timedtexttracks'])
             if not any(text_track.get('isForcedNarrative', False) is True and

--- a/resources/lib/services/playback/stream_continuity.py
+++ b/resources/lib/services/playback/stream_continuity.py
@@ -43,8 +43,8 @@ class StreamContinuityManager(PlaybackActionManager):
 
     def __init__(self):  # pylint: disable=super-on-old-class
         super(StreamContinuityManager, self).__init__()
-        self.current_videoid = None
         self.videoid = None
+        self.current_videoid = None
         self.current_streams = {}
         self.sc_settings = {}
         self.player = xbmc.Player()
@@ -54,14 +54,13 @@ class StreamContinuityManager(PlaybackActionManager):
         self.kodi_only_forced_subtitles = None
 
     def _initialize(self, data):
-        videoid = common.VideoId.from_dict(data['videoid'])
-        if videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
+        self.videoid = common.VideoId.from_dict(data['videoid'])
+        if self.videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
             self.enabled = False
             return
-        self.videoid = videoid
-        self.current_videoid = videoid \
-            if videoid.mediatype == common.VideoId.MOVIE \
-            else videoid.derive_parent(0)
+        self.current_videoid = self.videoid \
+            if self.videoid.mediatype == common.VideoId.MOVIE \
+            else self.videoid.derive_parent(0)
         self.sc_settings = g.SHARED_DB.get_stream_continuity(g.LOCAL_DB.get_active_profile_guid(),
                                                              self.current_videoid.value, {})
         self.kodi_only_forced_subtitles = common.get_kodi_subtitle_language() == 'forced_only'


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [X] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [X] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [X] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [X] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
On Kodi 18.6 and playback of an TV episode the plugin 100% throws a StreamContinuityManager exception.  The issue appears to be that current_videoid is pointing to the TV Show ID and not the individual episode ID that the cache entry was created for.

<pre>
2020-05-02 14:47:38.619 T:3872   ERROR: [plugin.video.netflix (0)] Traceback (most recent call last):
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\services\playback\controller.py", line 189, in _notify_managers
                                                notify_method(data)
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\services\playback\action_manager.py", line 59, in on_playback_started
                                                player_state=player_state)
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\services\playback\action_manager.py", line 94, in _call_if_enabled
                                                target_func(**kwargs)
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\services\playback\stream_continuity.py", line 74, in _on_playback_started
                                                self._show_only_forced_subtitle()
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\services\playback\stream_continuity.py", line 250, in _show_only_forced_subtitle
                                                manifest_data = g.CACHE.get(CACHE_MANIFESTS, cache_identifier)
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\common\cache.py", line 39, in get
                                                data = self._make_call('get', call_args)
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\common\cache.py", line 92, in _make_call_service
                                                return getattr(g.CACHE_MANAGEMENT, callname)(**params)
                                              File "C:\Users\Media 1\AppData\Roaming\Kodi\addons\plugin.video.netflix\resources\lib\services\cache\cache_management.py", line 135, in get
                                                raise CacheMiss()
                                            CacheMiss
</pre>

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
