### PR TITLE
Fix timestamp sent in event status updates

### DIFF
--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -200,7 +200,7 @@ class EventsHandler(threading.Thread):
         # Get previous elaborated data of the same video id
         # Some tags must remain unchanged between events
         previous_data, previous_player_state = self.cache_data_events.get(videoid.value, ({}, None))
-        timestamp = int(time.time() * 10000)
+        timestamp = int(time.time() * 1000)
 
         # Context location values can be easily viewed from tag data-ui-tracking-context
         # of a preview box in website html

--- a/resources/lib/services/msl/msl_utils.py
+++ b/resources/lib/services/msl/msl_utils.py
@@ -199,7 +199,7 @@ def generate_logblobs_params():
         # 'jssid': '15822792997793',  # Same value of appId
         # 'jsoffms': 1261,
         'clienttime': timestamp,
-        'client_utc': timestamp_utc,
+        'client_utc': int(timestamp_utc),
         'uiver': g.LOCAL_DB.get_value('ui_version', '', table=TABLE_SESSION)
     }
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [X] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [X] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [X] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [X] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
In profile / account / viewing activity when using "Playback > Synchronize the watched status of the videos with Netfllix" the dates are in the future by almost a full month.  My guess is Netflix probably has an upper limit on how much clock skew they will accept from the client and they just truncate it at a certain point.

Based on debugging with the Netflix Player in Firefox it is apparent that timestamps are in milliseconds since Unix time epoch.  But we are sending the value 10x greater since time.time() returns Unix time + fractional seconds, so the factor should be 1000.

I suspect there are a few other areas where timestamps may be incorrect, but they don't seem to have any negative effect.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
![Capture](https://user-images.githubusercontent.com/47257594/81024386-47645e80-8e41-11ea-938c-affb543b12c0.PNG)
