### PR TITLE
Occassional issues with watched status (duration set to 0)

### DIFF
--- a/resources/lib/services/playback/action_controller.py
+++ b/resources/lib/services/playback/action_controller.py
@@ -126,7 +126,8 @@ class ActionController(xbmc.Monitor):
         self.active_player_id = None
         # Immediately send the request to release the license
         common.send_signal(signal=common.Signals.RELEASE_LICENSE, non_blocking=True)
-        self._notify_all(ActionManager.call_on_playback_stopped)
+        self._notify_all(ActionManager.call_on_playback_stopped,
+                         self._last_player_state)
         self.action_managers = None
 
     def _notify_all(self, notification, data=None):

--- a/resources/lib/services/playback/action_manager.py
+++ b/resources/lib/services/playback/action_manager.py
@@ -82,11 +82,11 @@ class ActionManager(object):
         """
         self._call_if_enabled(self.on_playback_resume, player_state=player_state)
 
-    def call_on_playback_stopped(self):
+    def call_on_playback_stopped(self, player_state):
         """
         Notify that a playback has stopped
         """
-        self._call_if_enabled(self.on_playback_stopped)
+        self._call_if_enabled(self.on_playback_stopped, player_state=player_state)
         self.enabled = None
 
     def _call_if_enabled(self, target_func, **kwargs):
@@ -126,5 +126,5 @@ class ActionManager(object):
     def on_playback_resume(self, player_state):
         pass
 
-    def on_playback_stopped(self):
+    def on_playback_stopped(self, player_state):
         pass

--- a/resources/lib/services/playback/am_section_skipping.py
+++ b/resources/lib/services/playback/am_section_skipping.py
@@ -83,6 +83,6 @@ class AMSectionSkipper(ActionManager):
                              skip_to=self.markers[section]['end'],
                              label=common.get_local_string(SKIPPABLE_SECTIONS[section]))
 
-    def on_playback_stopped(self):
+    def on_playback_stopped(self, player_state):
         # Close any dialog remaining open
         xbmc.executebuiltin('Dialog.Close(all,true)')

--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -30,7 +30,6 @@ class AMVideoEvents(ActionManager):
         self.is_event_start_sent = False
         self.last_tick_count = 0
         self.tick_elapsed = 0
-        self.last_player_state = {}
         self.is_player_in_pause = False
         self.lock_events = False
         self.allow_request_update_lolomo = False
@@ -52,8 +51,8 @@ class AMVideoEvents(ActionManager):
             return
         if self.is_player_in_pause and (self.tick_elapsed - self.last_tick_count) >= 1800:
             # When the player is paused for more than 30 minutes we interrupt the sending of events (1800secs=30m)
-            self._send_event(EVENT_ENGAGE, self.event_data, self.last_player_state)
-            self._send_event(EVENT_STOP, self.event_data, self.last_player_state)
+            self._send_event(EVENT_ENGAGE, self.event_data, player_state)
+            self._send_event(EVENT_STOP, self.event_data, player_state)
             self.is_event_start_sent = False
             self.lock_events = True
         else:
@@ -76,7 +75,6 @@ class AMVideoEvents(ActionManager):
                     # Allow request of lolomo update (for continueWatching and bookmark) only after the first minute
                     # it seems that most of the time if sent earlier returns error
                     self.allow_request_update_lolomo = True
-        self.last_player_state = player_state
         self.tick_elapsed += 1  # One tick almost always represents one second
 
     def on_playback_pause(self, player_state):
@@ -104,8 +102,8 @@ class AMVideoEvents(ActionManager):
         if not self.is_event_start_sent or self.lock_events:
             return
         self._reset_tick_count()
-        self._send_event(EVENT_ENGAGE, self.event_data, self.last_player_state)
-        self._send_event(EVENT_STOP, self.event_data, self.last_player_state)
+        self._send_event(EVENT_ENGAGE, self.event_data, player_state)
+        self._send_event(EVENT_STOP, self.event_data, player_state)
 
     def _save_resume_time(self, resume_time):
         """Save resume time value in order to update the infolabel cache"""

--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -100,7 +100,7 @@ class AMVideoEvents(ActionManager):
         self._save_resume_time(player_state['elapsed_seconds'])
         self.allow_request_update_lolomo = True
 
-    def on_playback_stopped(self):
+    def on_playback_stopped(self, player_state):
         if not self.is_event_start_sent or self.lock_events:
             return
         self._reset_tick_count()


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [X] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [X] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [X] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [X] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
It appears if you let a video play to completion when Kodi is stopping the player there is a chance the on_tick fires pulls the player state and the time is set to 0.

~The solution is a bit of a hack, your choice if there is a better way.  But the fix seems to work.  The basic idea is to only update last_player_state (which is what is used when sending the stop event) if the elapsed_seconds has increased.  To accommodate rewinds I also force an update of the last_player_state in the on_playback_seek method.~

~Also in on_tick, I moved the saving of player state because when the video has been paused for more than 30 minutes it sends last_player_state so I didn't think it made sense to update it, but I may not understand the consequences of doing that.~

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
