### PR TITLE
Impl. of auto select of the last partial watched or next episode to be watched

### DIFF
--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (niedriger Index ist besser)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (el índice más bajo es mejor)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -974,3 +974,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (alacsonyabb index jobb)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (l'indice più basso è il migliore)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -973,3 +973,7 @@ msgstr ""
 msgctxt "#30242"
 msgid "Top 10"
 msgstr ""
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (niższy indeks jest lepszy)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (o índice mais baixo é melhor)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (indicele mai mic este mai bun)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (lägre siffra är bättre)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -973,3 +973,7 @@ msgstr "Open Connect CDN (alt dizin daha iyidir)"
 msgctxt "#30242"
 msgid "Top 10"
 msgstr "Top 10"
+
+msgctxt "#30243"
+msgid "Select first unwatched TV show episode"
+msgstr ""

--- a/resources/lib/navigation/directory.py
+++ b/resources/lib/navigation/directory.py
@@ -18,7 +18,7 @@ import resources.lib.kodi.ui as ui
 from resources.lib.database.db_utils import TABLE_MENU_DATA
 from resources.lib.globals import g
 from resources.lib.navigation.directory_utils import (finalize_directory, convert_list_to_dir_items, custom_viewmode,
-                                                      end_of_directory, get_title, activate_profile)
+                                                      end_of_directory, get_title, activate_profile, auto_scroll)
 
 # What means dynamic menus (and dynamic id):
 #  Are considered dynamic menus all menus which context name do not exists in the 'lolomo_contexts' of
@@ -135,6 +135,7 @@ class Directory(object):
         finalize_directory(convert_list_to_dir_items(list_data), g.CONTENT_EPISODE, 'sort_episodes',
                            title=extra_data.get('title', ''))
         end_of_directory(self.dir_update_listing)
+        auto_scroll(list_data)
 
     @common.time_execution(immediate=False)
     @custom_viewmode(g.VIEW_SHOW)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -107,6 +107,7 @@
     <setting id="pause_on_skip" type="bool" label="30080" default="false" visible="eq(-1,true)" subsetting="true"/>
     <setting id="forced_subtitle_workaround" type="bool" label="30181" default="true" />
     <setting id="ProgressManager_enabled" type="bool" label="30235" default="false"/>
+    <setting id="select_first_unwatched" type="bool" label="30243" default="false" visible="eq(-1,true)" subsetting="true"/>
     <setting label="30049" type="lsep"/><!--Library-->
     <setting id="library_playback_ask_profile" type="bool" label="30051" default="true"/>
     <setting id="library_playback_profile" type="action" label="30050" default="" action="RunPlugin(plugin://plugin.video.netflix/action/library_playback_profile/)" visible="eq(-1,false)" subsetting="true" option="close"/>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
A hacky implementation to auto select the next episode to watch without scroll manually every time
Kodi not offer this feature... this is better than nothing...

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
