### PR TITLE
Version bump (1.7.0)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.netflix" name="Netflix" version="1.6.1" provider-name="libdev + jojo + asciidisco + caphm + castagnait">
+<addon id="plugin.video.netflix" name="Netflix" version="1.7.0" provider-name="libdev + jojo + asciidisco + caphm + castagnait">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
     <import addon="script.module.addon.signals" version="0.0.3"/>
@@ -82,9 +82,21 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=329767</forum>
     <source>https://github.com/CastagnaIT/plugin.video.netflix</source>
     <news>
-v1.6.1 (2020-07-08)
--Fixed broken search menu on fresh installations
--Updated el-gr translation
+v1.7.0 (2020-07-28)
+-Big improvement in loading lists when you have many titles to My list
+-Refactor of nfsession
+-Refactor/improved library code:
+  -Improved speed and cpu use in autoupdate/sync in background
+  -Suppressed continuous appearance of loading screen when autoupdate/sync in background
+  -Widgets/Favourites managed without profile selection
+  -New Import existing library feature
+  -Play From Here context menu is fixed
+  -Reintroduced UpNext fast video playback feature
+  -Very long list of improvements/fixes full list on GitHub PR-756, PR-761
+-Managed error to account not reactivacted
+-New Chinese (simple) language translation
+-Updated translations it, sv-se, fr, de, jp, kr, hu, pl, es, pt-br, ru
+-Many other changes
     </news>
   </extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+v1.7.0 (2020-07-28)
+-Big improvement in loading lists when you have many titles to My list
+-Refactor of nfsession
+-Refactor/improved library code:
+  -Improved speed and cpu use in autoupdate/sync in background
+  -Suppressed continuous appearance of loading screen when autoupdate/sync in background
+  -Widgets/Favourites managed without profile selection
+  -New Import existing library feature
+  -Play From Here context menu is fixed
+  -Reintroduced UpNext fast video playback feature
+  -Very long list of improvements/fixes full list on GitHub PR-756, PR-761
+-Managed error to account not reactivacted
+-New Chinese (simple) language translation
+-Updated translations it, sv-se, fr, de, jp, kr, hu, pl, es, pt-br, ru
+-Many other changes
+
 v1.6.1 (2020-07-08)
 -Fixed broken search menu on fresh installations
 -Updated el-gr translation


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](Contributing.md) document.
* [x] I made sure there wasn't another one [Pull Requests](../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Version bump (1.7.0)

## BRAKING CHANGE FOR LIBRARY STRM FILES

This release will modify all STRM files in your library (if you have NF exported tv show/movies),
to make them compatible with this and future versions of the add-on.

This will cause problems in case of version rollback, _only if you have to play videos from Kodi library_.

### ADD-ON VERSION ROLLBACK, ONLY TO USERS THAT USE KODI LIBRARY:
**If possible, after the upgrade avoid to do a version rollback, at least on this version transition.**

**What happen if you try to do the add-on version rollback:**
You can not play the exported tvshow/movies in the Kodi library, the add-on will raise the error `InvalidPathError`.
This because the new STRM format is not handled from old add-on version.

**What happen if you try to play an old STRM file format to the new 1.7.0 version (should never happen)**
- The profile selection will be broken, then could cause problems with Age restrictions, Titles not allowed, wrong languages
- Side effects of sync netflix watched status feature (unwanted progress could be saved also on wrong profiles)
- UpNext add-on will not works correctly
- STRM video resume workaround will not works
- And other side effects...

In this case to fix the problem it is possible run the new `Import existing library` feature, under `Library` section of add-on settings.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
