### PR TITLE
Update the French translation for 1.7.0

### DIFF
--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: plugin.video.netflix\n"
 "Report-Msgid-Bugs-To: https://github.com/CastagnaIT/plugin.video.netflix\n"
 "POT-Creation-Date: 2017-11-23 16:15+0000\n"
-"PO-Revision-Date: 2020-06-20 18:40+0000\n"
+"PO-Revision-Date: 2020-07-26 18:40+0000\n"
 "Last-Translator: thombet\n"
 "Language-Team: Français\n"
 "MIME-Version: 1.0\n"
@@ -26,7 +26,7 @@ msgstr "Extension Netflix SVoD"
 
 msgctxt "Addon Disclaimer"
 msgid "The use of this add-on may not be legal in your country of residence - please check with your local laws before installing."
-msgstr "Certaines parties de cette extension peuvent ne pas être légales dans votre pays de résidence - renseignez-vous avant de l'installer"
+msgstr "L'utilisation de cette extension n'est peut-être pas légale dans votre pays de résidence - renseignez-vous avant de l'installer"
 
 msgctxt "#30001"
 msgid "Recommendations"
@@ -196,7 +196,7 @@ msgstr "Il y a un problème avec l'extension InputStrean Adaptive ou avec la bib
 
 msgctxt "#30047"
 msgid "Library update in progress"
-msgstr ""
+msgstr "Mise à jour de la médiathèque en cours"
 
 msgctxt "#30048"
 msgid "Exported"
@@ -238,7 +238,7 @@ msgstr "Le profil {} a été choisi pour la sélection automatique"
 
 msgctxt "#30059"
 msgid "Be careful, you are about to update many titles {}.[CR]This may cause service problems or temporary ban of the account.[CR]Do you want to continue?"
-msgstr ""
+msgstr "Attention, vous allez mettre à jour plusieurs titres {}.[CR]Cela pourrait entrainer des problèmes d'utilisation ou le blocage temporaire du compte.[CR]Voulez-vous continuer ?"
 
 msgctxt "#30060"
 msgid "Enable HEVC profiles (4k for Android/HDR/DolbyVision)"
@@ -254,7 +254,7 @@ msgstr "Contrôle parental"
 
 msgctxt "#30063"
 msgid "An update is already in progress"
-msgstr ""
+msgstr "Une mise à jour est déjà en cours"
 
 msgctxt "#30064"
 msgid "Perform auto-update"
@@ -494,7 +494,7 @@ msgstr "Synchroniser 'Ma Liste' vers la médiathèque Kodi"
 
 msgctxt "#30123"
 msgid "Do you want to continue?[CR]The full synchronization will delete all previously exported titles.[CR]If there are many titles this operation may take some time."
-msgstr ""
+msgstr "Voulez-vous continuer ?[CR]La synchronisation complète va supprimer tous les titres précédemment exportés.[CR]S'il y a beaucoup de titres cette opération peut prendre du temps."
 
 msgctxt "#30124"
 msgid "Do you want to remove this item from the library?"
@@ -562,7 +562,7 @@ msgstr "Activer IPC via HTTP (à activer si l'extension 'Addon Signals' retourne
 
 msgctxt "#30140"
 msgid "Import existing library"
-msgstr ""
+msgstr "Importer la médiathèque existante"
 
 msgctxt "#30141"
 msgid "Disable startup notification"
@@ -720,7 +720,7 @@ msgstr "Bandes annonces et plus"
 
 msgctxt "#30180"
 msgid "There has been a problem with login, it is possible that your account has not been confirmed or reactivated."
-msgstr ""
+msgstr "Il y a eu un problème de connexion, peut-être que votre compte n'a pas été confirmé ou réactivé."
 
 msgctxt "#30181"
 msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
@@ -909,7 +909,7 @@ msgstr "Synchronisation de la médiathèque Kodi avec 'Ma Liste'"
 
 msgctxt "#30228"
 msgid "Set a profile for synchronization"
-msgstr ""
+msgstr "Choisir le profil pour la synchronisation"
 
 # Unused 30229
 
@@ -975,11 +975,11 @@ msgstr "Forcer le niveau de sécurité L3 de Widevine"
 
 msgctxt "#30245"
 msgid "Deleting files exported to the library"
-msgstr ""
+msgstr "Suppression des fichers exportés dans la médiathèque"
 
 msgctxt "#30246"
 msgid "There are {} titles that cannot be imported.[CR]Do you want to delete these files?"
-msgstr ""
+msgstr "{} titres n'ont pas pu être importés.[CR]Voulez-vous supprimer ces fichiers ?"
 
 # Unused 30247 to 30299
 


### PR DESCRIPTION
See #306 

@CastagnaIT there is no disclaimer line for the French language in addon.xml and I was not sure if it was on purpose. Should I create it?
For my information why is the line duplicate in the files addon.xml and string.po? There is no way to use the string from strings.po in addon.xml?