### PR TITLE
Fix search results via JSON-RPC and prevent search retrigger onback

### DIFF
--- a/resources/lib/navigation/directory.py
+++ b/resources/lib/navigation/directory.py
@@ -46,7 +46,10 @@ class Directory(object):
         # After build url the param value is converted as string
         self.perpetual_range_start = (None if self.params.get('perpetual_range_start') == 'None'
                                       else self.params.get('perpetual_range_start'))
-        self.dir_update_listing = bool(self.perpetual_range_start)
+        if 'dir_update_listing' in self.params:
+            self.dir_update_listing = self.params['dir_update_listing'] == 'True'
+        else:
+            self.dir_update_listing = bool(self.perpetual_range_start)
         if self.perpetual_range_start == '0':
             # For cache identifier purpose
             self.perpetual_range_start = None


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
This will allow search to return a directory of results via JSON-RPC. Fixes https://github.com/CastagnaIT/plugin.video.netflix/issues/855

Also fixes issues with onback causing search add/clear to retrigger.
