### PR TITLE
Fixed slow list creation on RaspberryPi devices by disabling the art …

### DIFF
--- a/resources/lib/common/cache_utils.py
+++ b/resources/lib/common/cache_utils.py
@@ -32,7 +32,6 @@ CACHE_GENRES = {'name': 'cache_genres', 'is_persistent': False, 'default_ttl': '
 CACHE_SUPPLEMENTAL = {'name': 'cache_supplemental', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_METADATA = {'name': 'cache_metadata', 'is_persistent': True, 'default_ttl': 'CACHE_METADATA_TTL'}
 CACHE_INFOLABELS = {'name': 'cache_infolabels', 'is_persistent': True, 'default_ttl': 'CACHE_METADATA_TTL'}
-CACHE_ARTINFO = {'name': 'cache_artinfo', 'is_persistent': True, 'default_ttl': 'CACHE_METADATA_TTL'}
 CACHE_MANIFESTS = {'name': 'cache_manifests', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_BOOKMARKS = {'name': 'cache_bookmarks', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_MYLIST = {'name': 'cache_mylist', 'is_persistent': False, 'default_ttl': 'CACHE_MYLIST_TTL'}
@@ -40,10 +39,10 @@ CACHE_SEARCH = {'name': 'cache_search', 'is_persistent': False, 'default_ttl': '
 
 # The complete list of buckets (to obtain the list quickly)
 BUCKET_NAMES = ['cache_common', 'cache_genres', 'cache_supplemental', 'cache_metadata', 'cache_infolabels',
-                'cache_artinfo', 'cache_manifests', 'cache_bookmarks', 'cache_mylist', 'cache_search']
+                'cache_manifests', 'cache_bookmarks', 'cache_mylist', 'cache_search']
 
 BUCKETS = [CACHE_COMMON, CACHE_GENRES, CACHE_SUPPLEMENTAL, CACHE_METADATA, CACHE_INFOLABELS,
-           CACHE_ARTINFO, CACHE_MANIFESTS, CACHE_BOOKMARKS, CACHE_MYLIST, CACHE_SEARCH]
+           CACHE_MANIFESTS, CACHE_BOOKMARKS, CACHE_MYLIST, CACHE_SEARCH]
 
 
 # Logic to get the identifier

--- a/resources/lib/common/cache_utils.py
+++ b/resources/lib/common/cache_utils.py
@@ -30,8 +30,8 @@ except NameError:  # Python 3
 CACHE_COMMON = {'name': 'cache_common', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_GENRES = {'name': 'cache_genres', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_SUPPLEMENTAL = {'name': 'cache_supplemental', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
-CACHE_METADATA = {'name': 'cache_metadata', 'is_persistent': True, 'default_ttl': 'CACHE_METADATA_TTL'}
-CACHE_INFOLABELS = {'name': 'cache_infolabels', 'is_persistent': True, 'default_ttl': 'CACHE_METADATA_TTL'}
+CACHE_METADATA = {'name': 'cache_metadata', 'is_persistent': False, 'default_ttl': 'CACHE_METADATA_TTL'}
+CACHE_INFOLABELS = {'name': 'cache_infolabels', 'is_persistent': False, 'default_ttl': 'CACHE_METADATA_TTL'}
 CACHE_MANIFESTS = {'name': 'cache_manifests', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_BOOKMARKS = {'name': 'cache_bookmarks', 'is_persistent': False, 'default_ttl': 'CACHE_TTL'}
 CACHE_MYLIST = {'name': 'cache_mylist', 'is_persistent': False, 'default_ttl': 'CACHE_MYLIST_TTL'}

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -17,7 +17,7 @@ import resources.lib.utils.api_paths as paths
 import resources.lib.utils.api_requests as api
 import resources.lib.common as common
 from resources.lib.common.exceptions import CacheMiss, ItemNotFound
-from resources.lib.common.cache_utils import CACHE_BOOKMARKS, CACHE_INFOLABELS, CACHE_ARTINFO
+from resources.lib.common.cache_utils import CACHE_BOOKMARKS, CACHE_INFOLABELS
 from resources.lib.globals import G
 from resources.lib.utils.logging import LOG
 
@@ -103,19 +103,15 @@ def _add_supplemental_plot_info(infos_copy, item, common_data):
         infos_copy.update({'PlotOutline': plotoutline + suppl_text})
 
 
-def get_art(videoid, item, profile_language_code=''):
+def get_art(videoid, item):
     """Get art infolabels"""
-    return _get_art(videoid, item or {}, profile_language_code)
+    return _get_art(videoid, item or {})
 
 
-def _get_art(videoid, item, profile_language_code):
+def _get_art(videoid, item):
     # If item is None this method raise TypeError
-    cache_identifier = videoid.value + '_' + profile_language_code
-    try:
-        art = G.CACHE.get(CACHE_ARTINFO, cache_identifier)
-    except CacheMiss:
-        art = parse_art(videoid, item)
-        G.CACHE.add(CACHE_ARTINFO, cache_identifier, art)
+
+    art = parse_art(videoid, item)
     return art
 
 
@@ -258,7 +254,7 @@ def get_info_from_netflix(videoids):
     for videoid in videoids:
         try:
             infos = get_info(videoid, None, None, profile_language_code)[0]
-            art = _get_art(videoid, None, profile_language_code)
+            art = _get_art(videoid, None)
             info_data[videoid.value] = infos, art
             LOG.debug('Got infolabels and art from cache for videoid {}', videoid)
         except (AttributeError, TypeError):
@@ -270,7 +266,7 @@ def get_info_from_netflix(videoids):
         raw_data = api.get_video_raw_data(videoids_to_request)
         for videoid in videoids_to_request:
             infos = get_info(videoid, raw_data['videos'][videoid.value], raw_data, profile_language_code)[0]
-            art = get_art(videoid, raw_data['videos'][videoid.value], profile_language_code)
+            art = get_art(videoid, raw_data['videos'][videoid.value])
             info_data[videoid.value] = infos, art
     return info_data
 

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -154,7 +154,7 @@ def _create_season_item(tvshowid, seasonid_value, season, season_list, common_da
         'properties': {'nf_videoid': seasonid.to_string()}
     }
     add_info_dict_item(dict_item, seasonid, season, season_list.data, False, common_data)
-    dict_item['art'] = get_art(tvshowid, season, common_data['profile_language_code'])
+    dict_item['art'] = get_art(tvshowid, season)
     dict_item['url'] = common.build_url(videoid=seasonid, mode=G.MODE_DIRECTORY)
     dict_item['menu_items'] = generate_context_menu_items(seasonid, False, None)
     return dict_item
@@ -186,7 +186,7 @@ def _create_episode_item(seasonid, episodeid_value, episode, episodes_list, comm
                  'properties': {'nf_videoid': episodeid.to_string()}}
     add_info_dict_item(dict_item, episodeid, episode, episodes_list.data, False, common_data)
     set_watched_status(dict_item, episode, common_data)
-    dict_item['art'] = get_art(episodeid, episode, common_data['profile_language_code'])
+    dict_item['art'] = get_art(episodeid, episode)
     dict_item['url'] = common.build_url(videoid=episodeid, mode=G.MODE_PLAY, params=common_data['params'])
     dict_item['menu_items'] = generate_context_menu_items(episodeid, False, None)
     return dict_item
@@ -249,7 +249,7 @@ def _create_videolist_item(list_id, video_list, menu_data, common_data, static_l
     dict_item = {'label': video_list['displayName'],
                  'is_folder': True}
     add_info_dict_item(dict_item, video_list.videoid, video_list, video_list.data, False, common_data)
-    dict_item['art'] = get_art(video_list.videoid, video_list.artitem, common_data['profile_language_code'])
+    dict_item['art'] = get_art(video_list.videoid, video_list.artitem)
     # Add possibility to browse the sub-genres (see build_video_listing)
     sub_genre_id = video_list.get('genreId')
     params = {'sub_genre_id': unicode(sub_genre_id)} if sub_genre_id else None
@@ -316,7 +316,7 @@ def _create_video_item(videoid_value, video, video_list, perpetual_range_start, 
                                 'nf_perpetual_range_start': perpetual_range_start}}
     add_info_dict_item(dict_item, videoid, video, video_list.data, is_in_mylist, common_data)
     set_watched_status(dict_item, video, common_data)
-    dict_item['art'] = get_art(videoid, video, common_data['profile_language_code'])
+    dict_item['art'] = get_art(videoid, video)
     dict_item['url'] = common.build_url(videoid=videoid,
                                         mode=G.MODE_DIRECTORY if is_folder else G.MODE_PLAY,
                                         params=None if is_folder else common_data['params'])


### PR DESCRIPTION
…caching.

* the pure parse_art call is faster than the call into the cache (even if there is no cache miss)
** the cache call is more than 10x slower (even if it is non persistent)
* fixed timeouts on during list browsing (especially on longer lists)

### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
On my Kodi installation on a RaspberryPi4 I got constant timeouts during list browsing and it was way slower than it used to be.
I investigated a bit and found out that the art caching is super slow compared to not doing any caching (even the call into the cache without a miss is way slower)
