### PR TITLE
Addon Signals Call Timeout

### DIFF
--- a/resources/lib/common/ipc.py
+++ b/resources/lib/common/ipc.py
@@ -24,7 +24,7 @@ try:  # Python 2
 except NameError:  # Python 3
     unicode = str  # pylint: disable=redefined-builtin
 
-IPC_TIMEOUT_SECS = 20
+IPC_TIMEOUT_SECS = 30
 IPC_EXCEPTION_PLACEHOLDER = 'IPC_EXCEPTION_PLACEHOLDER'
 
 


### PR DESCRIPTION
With more service add-ons and the use of more widgets, the Netflix addon is delayed, the widgets are not loaded, and a message and "Addon Signals Call Timeout" are displayed.

Minor repair

# Check if this PR fulfills these requirements:
* [ ] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [ ] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
