### PR TITLE
Execute a single db transaction for all add operations

### DIFF
--- a/resources/lib/common/cache.py
+++ b/resources/lib/common/cache.py
@@ -39,7 +39,7 @@ class Cache(object):
         data = self._make_call('get', call_args)
         return deserialize_data(data)
 
-    def add(self, bucket, identifier, data, ttl=None, expires=None):
+    def add(self, bucket, identifier, data, ttl=None, expires=None, delayed_db_op=False):
         """
         Add or update an item to a cache bucket
 
@@ -48,13 +48,17 @@ class Cache(object):
         :param data: the content
         :param ttl: override default expiration (in seconds)
         :param expires: override default expiration (in timestamp) if specified override also the 'ttl' value
+        :param delayed_db_op: if True, queues the adding operation for the db, then is mandatory to call
+                      'execute_pending_db_add' at end of all operations to apply the changes to the db
+                      (only for persistent buckets)
         """
         call_args = {
             'bucket': bucket,
             'identifier': identifier,
             'data': None,  # This value is injected after the _make_call
             'ttl': ttl,
-            'expires': expires
+            'expires': expires,
+            'delayed_db_op': delayed_db_op
         }
         self._make_call('add', call_args, serialize_data(data))
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
When a devices has a old/economy sdcard or mechanical hdd with poor speed performance,
do not have enough speed to perform multiple individual db writing operations in a faster way.

This cause a long delay in loading the lists the first time,
and in worst cases the possibility to raise AddonSignals: call timeout error

To fix this making a single db write transaction for all changes greatly speeds up the loading of the lists.

Thanks to @xLAva for pointing out the problem

### Tests performed
**On Windows + old mechanical HDD + list of 90 entry list**
BEFORE: Call to build_video_listing took 19153ms
AFTER: Call to build_video_listing took 849ms

**On RPI4 + Slow SDCard + list of 40 entry list**
BEFORE: Call to build_video_listing took 10251ms
AFTER: Call to build_video_listing took 1250ms

This should finally close the circle to full solve the AddonSignals call timeout problem
also with all users using RPI devices or similar low end devices

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
