### PR TITLE
Improvements to watched status behaviour

### DIFF
--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -112,6 +112,8 @@ class AMVideoEvents(ActionManager):
         self._reset_tick_count()
         self._send_event(EVENT_ENGAGE, self.event_data, player_state)
         self._send_event(EVENT_STOP, self.event_data, player_state)
+        # Update the resume here may not always work due to race conditions with refresh list/stop event
+        self._save_resume_time(player_state['elapsed_seconds'])
 
     def _save_resume_time(self, resume_time):
         """Save resume time value in order to update the infolabel cache"""


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Improvements to watched status, so when a video should be set as watched
More or less explained:

#### Case when netflix sync is enabled
The best way would be to use "watchedToEndOffset" value to identify if a video is watched,
but this value is avaiable only with metadata API and not shakty,
implementing metadata loading would make the code even more complex only for a small thing,
so i opted to lower the "creditsOffset" value by calculating a proportion where we
remove 50 seconds for 50 minutes of video
(it seems to me a good compromise based on the difference between the two values in the metadata)
This should ensure that a video is set to be watched even in cases where a user stops playback before the final credits are reached.

#### Case when netflix sync is disabled

Unlike netflix, Kodi watched status method use a percentage to set a video as watched,
so is set watched only when you reach the 90% + 2% (no mans land) = 92% of the video.
If the final credits are too long or the video duration is too short,
it may happen that the video will never be set as watched,
to avoid this in this case we have the metadata available, so we can use the "watchedToEndOffset"
value to understand if a video is watched and manually fix the kodi watched status

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
