### PR TITLE
Implemented clean library by directory

### DIFF
--- a/resources/lib/common/kodi_library_ops.py
+++ b/resources/lib/common/kodi_library_ops.py
@@ -68,18 +68,27 @@ def get_library_item_details(dbtype, itemid):
     return json_rpc(method, params)[dbtype + 'details']
 
 
-def scan_library(path=""):
-    """Start a Kodi library scanning in a specified folder to find new items"""
+def scan_library(path=''):
+    """
+    Start a Kodi library scanning in a specified folder to find new items
+    :param path: Update only the library elements in the specified path (fast processing)
+    """
     method = 'VideoLibrary.Scan'
-    params = {'directory': path}
+    params = {'directory': makeLegalFilename(translatePath(path))}
     return json_rpc(method, params)
 
 
-def clean_library(show_dialog=True):
-    """Start a Kodi library scanning to remove non-existing items"""
+def clean_library(show_dialog=True, path=''):
+    """
+    Start a Kodi library cleaning to remove non-existing items
+    :param show_dialog: True a progress dialog is shown
+    :param path: Clean only the library elements in the specified path (fast processing)
+    """
     method = 'VideoLibrary.Clean'
     params = {'content': 'video',
               'showdialogs': show_dialog}
+    if not G.KODI_VERSION.is_major_ver('18') and path:
+        params['directory'] = makeLegalFilename(translatePath(path))
     return json_rpc(method, params)
 
 

--- a/resources/lib/kodi/library.py
+++ b/resources/lib/kodi/library.py
@@ -169,7 +169,7 @@ class Library(LibraryTasks):
                 section_root_dir = common.join_folders_paths(get_library_path(), folder_name)
                 common.delete_folder_contents(section_root_dir, delete_subfolders=True)
         # Clean the Kodi library database
-        common.clean_library(show_prg_dialog)
+        common.clean_library(show_prg_dialog, get_library_path())
 
     def auto_update_library(self, sync_with_mylist, show_prg_dialog=True, show_nfo_dialog=False, clear_on_cancel=False,
                             update_profiles=False):

--- a/resources/lib/services/library_updater.py
+++ b/resources/lib/services/library_updater.py
@@ -19,16 +19,6 @@ import resources.lib.common as common
 from resources.lib.kodi.library_utils import get_library_path
 from resources.lib.utils.logging import LOG
 
-try:  # Kodi >= 19
-    from xbmcvfs import makeLegalFilename  # pylint: disable=ungrouped-imports
-except ImportError:  # Kodi 18
-    from xbmc import makeLegalFilename  # pylint: disable=ungrouped-imports
-
-try:  # Kodi >= 19
-    from xbmcvfs import translatePath  # pylint: disable=ungrouped-imports
-except ImportError:  # Kodi 18
-    from xbmc import translatePath  # pylint: disable=ungrouped-imports
-
 
 class LibraryUpdateService(xbmc.Monitor):
     """
@@ -146,9 +136,7 @@ class LibraryUpdateService(xbmc.Monitor):
             LOG.debug('Start Kodi library scan')
             self.scan_in_progress = True  # Set as in progress (avoid wait "started" callback it comes late)
             self.scan_awaiting = False
-            # Update only the library elements in the add-on export folder
-            # for faster processing (on Kodi 18.x) with a large library
-            common.scan_library(makeLegalFilename(translatePath(get_library_path())))
+            common.scan_library(get_library_path())
         else:
             self.scan_awaiting = True
 
@@ -157,7 +145,7 @@ class LibraryUpdateService(xbmc.Monitor):
             LOG.debug('Start Kodi library clean')
             self.clean_in_progress = True  # Set as in progress (avoid wait "started" callback it comes late)
             self.clean_awaiting = False
-            common.clean_library(False)
+            common.clean_library(False, get_library_path())
         else:
             self.clean_awaiting = True
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Clean library by directory is a new feature of Kodi 19, allow to:
- Do not touch part of the kodi library of other addons/directories or other services
- Speed up a lot the clean operation

This resolve the side effect of issue: https://github.com/CastagnaIT/plugin.video.netflix/issues/888

Requisites:
- latest Kodi build
- last Kodi build require new InputStream Adaptive version, currently in WIP, so not released
Some updated ISA builds here:
https://jenkins.kodi.tv/blue/organizations/jenkins/peak3d%2Finputstream.adaptive/activity

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
