### PR TITLE
Changes to directory behaviours and profile switch activation

### DIFF
--- a/resources/lib/common/kodi_ops.py
+++ b/resources/lib/common/kodi_ops.py
@@ -71,7 +71,7 @@ def container_refresh(use_delay=False):
         # seems to be caused by a race condition with the Kodi library update (but i am not really sure)
         from time import sleep
         sleep(1)
-    G.IS_CONTAINER_REFRESHED = True
+    WndHomeProps[WndHomeProps.IS_CONTAINER_REFRESHED] = 'True'
     xbmc.executebuiltin('Container.Refresh')
 
 

--- a/resources/lib/common/kodi_ops.py
+++ b/resources/lib/common/kodi_ops.py
@@ -117,12 +117,44 @@ def stop_playback():
 
 def get_current_kodi_profile_name(no_spaces=True):
     """Lazily gets the name of the Kodi profile currently used"""
-    # pylint: disable=global-statement
-    global __CURRENT_KODI_PROFILE_NAME__
-    if not __CURRENT_KODI_PROFILE_NAME__:
+    if not hasattr(get_current_kodi_profile_name, 'cached'):
         name = json_rpc('Profiles.GetCurrentProfile', {'properties': ['thumbnail', 'lockmode']}).get('label', 'unknown')
-        __CURRENT_KODI_PROFILE_NAME__ = name.replace(' ', '_') if no_spaces else name
-    return __CURRENT_KODI_PROFILE_NAME__
+        get_current_kodi_profile_name.cached = name.replace(' ', '_') if no_spaces else name
+    return get_current_kodi_profile_name.cached
+
+
+class _WndProps(object):  # pylint: disable=no-init
+    """Read and write a property to the Kodi home window"""
+    # Default Properties keys
+    SERVICE_STATUS = 'service_status'
+    """Return current service status"""
+    IS_CONTAINER_REFRESHED = 'is_container_refreshed'
+    """Return 'True' when container_refresh in kodi_ops.py is used by context menus, etc."""
+    CURRENT_DIRECTORY = 'current_directory'
+    """
+    Return the name of the currently loaded directory (so the method name of directory.py class), otherwise:
+    ['']       When the add-on is in his first run instance, so startup page
+    ['root']   When add-on startup page is re-loaded (like refresh) or manually called
+    Notice: In some cases the value may not be consistent example:
+     - when you exit to Kodi home
+     - external calls to the add-on while browsing the add-on
+    """
+    def __getitem__(self, key):
+        try:
+            # If you use multiple Kodi profiles you need to distinguish the property of current profile
+            return G.WND_KODI_HOME.getProperty(G.py2_encode('netflix_{}_{}'.format(get_current_kodi_profile_name(),
+                                                                                   key)))
+        except Exception:  # pylint: disable=broad-except
+            return ''
+
+    def __setitem__(self, key, newvalue):
+        # If you use multiple Kodi profiles you need to distinguish the property of current profile
+        G.WND_KODI_HOME.setProperty(G.py2_encode('netflix_{}_{}'.format(get_current_kodi_profile_name(),
+                                                                        key)),
+                                    newvalue)
+
+
+WndHomeProps = _WndProps()
 
 
 def get_kodi_audio_language(iso_format=xbmc.ISO_639_1, use_fallback=True):

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -26,6 +26,7 @@ except ImportError:  # Python 2
 from future.utils import iteritems
 
 import xbmcaddon
+from xbmcgui import Window
 
 try:  # Kodi >= 19
     from xbmcvfs import translatePath  # pylint: disable=ungrouped-imports
@@ -213,6 +214,7 @@ class GlobalVariables(object):
         # on subsequent add-on invocations (invoked by reuseLanguageInvoker) will have no effect.
         # Define here also any other variables necessary for the correct loading of the other project modules
         self.PY_IS_VER2 = sys.version_info.major == 2
+        self.WND_KODI_HOME = Window(10000)  # Kodi home window
         self.IS_ADDON_FIRSTRUN = None
         self.ADDON = None
         self.ADDON_DATA_PATH = None

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -224,11 +224,6 @@ class GlobalVariables(object):
         self.CACHE_TTL = None
         self.CACHE_MYLIST_TTL = None
         self.CACHE_METADATA_TTL = None
-        self.IS_CONTAINER_REFRESHED = False  # True when container_refresh in kodi_ops.py is used by context menus, etc.
-        # The currently loaded directory page (method name of directory.py):
-        # None value means in the real addon startup page, so first run instance
-        # 'root' value always means addon startup page, but in this case is called by a Container refresh or manually
-        self.CURRENT_LOADED_DIRECTORY = None
 
     def init_globals(self, argv, reinitialize_database=False, reload_settings=False):
         """Initialized globally used module variables. Needs to be called at start of each plugin instance!"""

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -154,10 +154,10 @@ def _execute(executor_type, pathitems, params, root_handler):
         executor = executor_type(params).__getattribute__(pathitems[0] if pathitems else 'root')
         LOG.debug('Invoking action: {}', executor.__name__)
         executor(pathitems=pathitems)
-        if root_handler == G.MODE_DIRECTORY:
+        if root_handler == G.MODE_DIRECTORY and not G.IS_ADDON_EXTERNAL_CALL:
             # Save the method name of current loaded directory
-            G.CURRENT_LOADED_DIRECTORY = executor.__name__
-            G.IS_CONTAINER_REFRESHED = False
+            WndHomeProps[WndHomeProps.CURRENT_DIRECTORY] = executor.__name__
+            WndHomeProps[WndHomeProps.IS_CONTAINER_REFRESHED] = None
     except AttributeError as exc:
         raise_from(InvalidPathError('Unknown action {}'.format('/'.join(pathitems))), exc)
 
@@ -200,7 +200,7 @@ def _check_addon_external_call():
     if is_other_plugin_name or not getCondVisibility("Window.IsMedia"):
         monitor = Monitor()
         sec_elapsed = 0
-        while not _get_service_status(window_cls, prop_nf_service_status).get('status') == 'running':
+        while not _get_service_status().get('status') == 'running':
             if sec_elapsed >= limit_sec or monitor.abortRequested() or monitor.waitForAbort(0.5):
                 break
             sec_elapsed += 0.5

--- a/resources/lib/run_service.py
+++ b/resources/lib/run_service.py
@@ -105,6 +105,8 @@ class NetflixService(object):
         self.controller = ActionController()
         self.library_updater = LibraryUpdateService()
         self.settings_monitor = SettingsMonitor()
+        # We reset the value in case of any eventuality (add-on disabled, update, etc)
+        WndHomeProps[WndHomeProps.CURRENT_DIRECTORY] = None
         # Mark the service as active
         self._set_service_status('running')
         if not G.ADDON.getSettingBool('disable_startup_notification'):

--- a/resources/lib/run_service.py
+++ b/resources/lib/run_service.py
@@ -11,11 +11,9 @@ from __future__ import absolute_import, division, unicode_literals
 import threading
 from socket import gaierror
 
-from xbmcgui import Window
-
 # Global cache must not be used within these modules, because stale values may
 # be used and cause inconsistencies!
-from resources.lib.common import select_port, get_local_string, get_current_kodi_profile_name
+from resources.lib.common import select_port, get_local_string, WndHomeProps
 from resources.lib.globals import G
 from resources.lib.upgrade_controller import check_service_upgrade
 from resources.lib.utils.logging import LOG
@@ -34,9 +32,6 @@ class NetflixService(object):
     HOST_ADDRESS = '127.0.0.1'
 
     def __init__(self):
-        self.window_cls = Window(10000)  # Kodi home window
-        # If you use multiple Kodi profiles you need to distinguish the property of current profile
-        self.prop_nf_service_status = G.py2_encode('nf_service_status_' + get_current_kodi_profile_name())
         self.controller = None
         self.library_updater = None
         self.settings_monitor = None
@@ -162,7 +157,7 @@ class NetflixService(object):
         """Save the service status to a Kodi property"""
         from json import dumps
         status = {'status': status, 'message': message}
-        self.window_cls.setProperty(self.prop_nf_service_status, dumps(status))
+        WndHomeProps[WndHomeProps.SERVICE_STATUS] = dumps(status)
 
 
 def run(argv):


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
This PR try to workaround the lack of support from Kodi framework of some important parts:
- Do not provide no way to understand if an instance of the add-on is the one used in the GUI interface (i.e. user interaction).
  You can not use infoLabels because they are based on what is shown on screen at a given time
- No way to determine the navigation history in the "session"
  You can not use variables with reuseLanguageInvoker feature, because if the python session is moved to a new instance values will be lost
- No way to determine from which component the add-on request comes from, to differentiate some behaviors

This complicates things to handle some particular situations in the code in this case the profile switch activation, in short:
The "home" directory method can be called when:
-Add-on startup
-Page refresh
-When you go back from a "home" submenu
-Could be called by another add-on or jsonRPC
-Could be called by widgets/path browsers/etc...
And is possible several circumstances together

I had tried to solve with PR: https://github.com/CastagnaIT/plugin.video.netflix/pull/893
but do not take in account of python session that can be moved to a new instance, then in some circumstances this will fails
(e.g. some skins call extrafanart to every path, and causes the creation of new instances),
and the previous old implementation with infoLabels can not work good.

So to try solve, i chose to save the last directory called in to a property in Kodi home,
this workaroud the problem better, even if it could fail in particular circumstances:
- exit to Kodi home
- add-on crash
- other calls (mentioned above) while the user browses the add-on (the identification of external calls in run_addon.py is infoLabels based...)

This include also two fixes:
Avoided profile autoselection when add-on is contained in a browser window
Avoid set current directory when an "external call" is identified


### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
