### PR TITLE
Reworked Audio/Subtitles language features

### DIFF
--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Zapamatovat si předvolby zvuku / titulků"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Uložit záložky pro knihovnu položky / značky jako zhlédnuté"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Došlo k potížím s přihlášením. Je možné, že váš účet nebyl potvrzen ani reaktivován."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Zakázat titulky, pokud neexistují nucené toky titulků (funguje, pouze pokud je Kodi Player nastaven na 'Pouze vynucené' titulky)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1051,4 +1051,13 @@ msgstr "Podle jazyka titulků"
 
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
+msgstr ""
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
 msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Audio- und Untertitel-Einstellungen beibehalten"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Fortschritt für Bibliothekseinträge speichern und als gesehen markieren"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Es gab ein Problem bei der Anmeldung, möglicherweise ist Ihr Account nicht bestätigt oder reaktiviert."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Deaktiviere Untertitel wenn keine erzwungenen Untertitel vorhanden sind (funktioniert nur wenn der Kodi-Player auf 'Nur erzwungen' eingesellt ist"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Nach Untertitelsprache"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Nach Genre/Subgenre ID"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Απομνημόνευση προτιμήσεων για ήχο / υποτίτλους"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Αποθήκευση σελιδοδεικτών για τα αντικείμενα βιβλιοθήκης / σήμανση ως προβληθέντα"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Υπάρχει πρόβλημα με την είσοδο σας, ενδεχομένως ο λογαριασμός σας να μην έχει (επάν)ενεργοποιηθεί"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Απενεργοποίηση των υποτίτλων εάν δεν υπάρχουν επιβεβλημένες ροές υποτίτλων (Δουλεύει μονο οταν ο αναπαραγωγέας του Kodi είναι ρυθμισμένος στους υπότιτλους 'Μόνο επιβεβλημένοι')"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Μέσω γλώσσας υποτίτλων"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Μέσω είδους/ID υπόειδους"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -331,7 +331,7 @@ msgid "Remember audio / subtitle preferences"
 msgstr ""
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
+msgid "Force the display of forced subtitles only with the audio language set"
 msgstr ""
 
 msgctxt "#30084"
@@ -717,7 +717,7 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr ""
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
+msgid "Always show the subtitles when the preferred audio language is not available"
 msgstr ""
 
 msgctxt "#30182"
@@ -1068,4 +1068,14 @@ msgstr ""
 
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
+msgstr ""
+
+# Unused 30414 to 30499
+
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Recordar preferencias de audio / subtítulos"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Guardar marcadores para elementos de la biblioteca / marcar como vistos"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Ha habido un problema con el inicio de sesión, es posible que su cuenta no haya sido confirmada o reactivada."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Deshabilitar subtítulos si no hay subtítulos forzados (sólo funciona si el reproductor de Kodi está establecido a subtítulos 'Sólo forzados')"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Por idioma de subtítulos"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Por ID de género/subgénero"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Se souvenir des préférences audio / sous-titres"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Sauvegarder les marque-pages des éléments de la médiathèque / marquer comme vu"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Il y a eu un problème de connexion, peut-être que votre compte n'a pas été confirmé ou réactivé."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Désactiver les sous-titres s'ils ne sont pas forcés (fonctionne seulement si Kodi n'utilise que les sous-titres forcés)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Par langue de sous-titres"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Par identifiant de genre/sous-genre"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -326,8 +326,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Lembrar preferencias de son / subtítulos"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Salvar marcadores como elementos da biblioteca / marcar como visto"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -709,8 +709,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Houbo un problema co acceso; é posíbel que a súa conta non fose confirmada ou reactivada."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Desactivar subtítulos se non houber fluxos de subtítulos forzados (Funciona soamente se o Reprodutor está configurado con subtítulos 'Só forzados’)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1054,3 +1054,12 @@ msgstr "Pola lingua dos subtítulos"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Polo ID do xénero/subxénero"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "לזכור העדפות כתוביות/שמע"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "לשמור מועדפים כפריטים בספרייה / לסמן כנצפה"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "ישנה בעיה בחיבור, יתכן שהחשבון שלך לא אושר או אופשר מחדש"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "לכבות כתוביות במידה ואין הזרמה בכח של כתוביות (עובד רק אם הנגן של Kodi מוגדר ל'הכרח כתוביות'"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1051,4 +1051,13 @@ msgstr "לפי שפת תרגום"
 
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
+msgstr ""
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
 msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -325,8 +325,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Zapamti postavke zvuka / titlova"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Spremi status gledanja za predmete zbirke / označi kao gledane"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -708,8 +708,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr ""
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Onemogućite titlove ako nema prisiljenih titlova (Radi samo ako je Kodi Player postavljen na 'Samo prisilni' titlovi)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,4 +1052,13 @@ msgstr ""
 
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
+msgstr ""
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
 msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Hang/felirat beállítások megjegyzése"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Könyvjelzők mentése / nézettként megjelölés"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Probléma merült fel a bejelentkezés során, lehetséges, hogy fiókját nem erősítették meg vagy nem aktiválták"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "A feliratok letiltása, ha nincs kényszerített felirat (csak akkor működik ha a Kodi 'Csak kényszerített' feliratra van állítva)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Feliratnyelv szerint"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Műfaj/alműfaj azonosító szerint"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Ricorda preferenze audio/sottotitoli"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Salva segnalibri per le voci della libreria / contrassegnate già viste"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Si è verificato un problema con l'accesso, è possibile che il vostro account non sia stato confermato oppure riattivato."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Disabilita i sottotitoli quando non ci sono tracce forzate (Funziona se il Player Kodi viene impostato con sottotitoli 'Solo forzati')"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Per lingua sottotitoli"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Per ID genere/sottogenere"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "音声・字幕設定を保存"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "ライブラリ項目と見た項目のブックマークを保存"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "ログイン失敗、アカウント確認がまだ取れてないか再入会が出来なかった可能性があります。"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "強制字幕のない場合、字幕を表示しない(Kodiプレイヤーが'強制字幕のみ'の場合)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "字幕"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "ジャンル／サーブジャンルID"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "음성/자막 설정 기억하기"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "라이브러리와 본 것들의 북마크를 저장합니다."
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "로그인에 문제가 있습니다. 계정이 아직 처리 중이거나 활성화 되지 않았을 수 있습니다."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Forced 자막이 없으면 자막을 표시하지 않습니다(Kodi플레이어가 'Forced 자막'으로 설정된 경우"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "자막"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "장르/서브장르ID"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Onthoud geluid / ondertiteling voorkeuren"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Bewaar favorieten voor de bibliotheek / markeer als bekeken"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Er is een probleem opgetreden met het inloggen. Het is mogelijk dat je account nog niet bevestigd of geheractiveerd is."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Ondertitels uitschakelen als er geen geforceerde ondertitels worden meegeleverd (Werkt enkel als Kodi Player 'Alleen geforceerde' ondertitles heeft ingeschakeld)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Op ondertitelingstaal"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Op genre/subgenre ID"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Pamiętaj ustawienia dźwięku i napisów"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Zachowaj zakładki dla pozycji biblioteki / oznacz jako obejrzane"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Wystąpił problem z logowaniem, możliwe, że Twoje konto nie zostało potwierdzone lub reaktywowane"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Wyłącz napisy, jeśli nie ma wymuszonych strumieni napisów (Działa tylko, jeśli odtwarzacz Kodi jest ustawiony na 'Tylko wymuszone' napisy)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Wg. języka napisów"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Wg. ID gatunku/podgatunku"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Lembrar preferências de áudio / legendas"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Salvar marcadores para itens na coleção / marcar como assistido"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Houve um problema com o login, é possível que sua conta não tenha sido confirmada ou reativada."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Desativar legendas se não houver fluxos de legendas forçadas (Funciona somente se o Kodi Player estiver configurado para legendas 'Somente forçadas')"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "Pelo idioma da legenda"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "Pelo ID do gênero/subgênero"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Memorează preferințele audio / pentru subtitrare"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Pune semne de carte pentru articolele din librărie / marchează ca văzute"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "A apărut o problemă cu conectarea, este posibil ca contul să nu fi fost confirmat sau reactivat"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Dezactivează subtitrările dacă sunt fluxuri cu subtitrări neforțate (funcționează doar dacă Kodi este configurat cu subtitrări 'Numai forțate')"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "După limba subtitrării"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "După gen/subgen"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Kom ihåg inställningarna för ljud och undertext"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Spara bokmärken för biblioteksposter / Markera som sedd"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "Det har uppstått ett problem med inloggningen, det är möjligt att ditt konto inte har bekräftats eller återaktiverats."
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Inaktivera undertexter om det inte finns några tvingade undertextsströmmar (Fungerar bara om Kodi Player är inställd på 'Endast tvingad' undertext)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1051,4 +1051,13 @@ msgstr "Efter undertextspråk"
 
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
+msgstr ""
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
 msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "Ses / altyazı tercihlerini hatırla"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "Kütüphane öğeleri için yer imlerini kaydet / izlendiğinde işaretle"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr ""
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "Zorunlu altyazı akışı yoksa altyazıları devre dışı bırak (Sadece Kodi Yürütücü 'Yalnızca zorunlu' altyazı olarak ayarlanmışsa çalışır)"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1051,4 +1051,13 @@ msgstr "Altyazı diline göre"
 
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
+msgstr ""
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
 msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -324,8 +324,8 @@ msgid "Remember audio / subtitle preferences"
 msgstr "记住音频/字幕首选项"
 
 msgctxt "#30083"
-msgid "Save bookmarks for library items / mark as watched"
-msgstr "保存图书馆项目的书签/标记为已观看"
+msgid "Force the display of forced subtitles only with the audio language set"
+msgstr ""
 
 msgctxt "#30084"
 msgid "Cache objects TTL (minutes)"
@@ -707,8 +707,8 @@ msgid "There has been a problem with login, it is possible that your account has
 msgstr "有一个登录的问题，可能是您的帐户没有被确认或重新激活。"
 
 msgctxt "#30181"
-msgid "Disable subtitles if there are no forced subtitles streams (Works only if Kodi Player is set to 'Only forced' subtitles)"
-msgstr "如果没有强制字幕流，则禁用字幕（仅当Kodi Player设置为“仅强制”字幕时才有效）"
+msgid "Always show the subtitles when the preferred audio language is not available"
+msgstr ""
 
 msgctxt "#30182"
 msgid "Export NFO files"
@@ -1052,3 +1052,12 @@ msgstr "通过字幕语言"
 msgctxt "#30413"
 msgid "By genre/subgenre ID"
 msgstr "按类型/子类型ID"
+
+# Unused 30414 to 30499
+msgctxt "#30500"
+msgid "Prefer the audio/subtitle language with country code (if available)"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Prefer stereo audio tracks by default"
+msgstr ""

--- a/resources/lib/common/kodi_ops.py
+++ b/resources/lib/common/kodi_ops.py
@@ -19,6 +19,15 @@ from .misc_utils import is_less_version
 
 __CURRENT_KODI_PROFILE_NAME__ = None
 
+LOCALE_CONV_TABLE = {
+    'es-ES': 'es-Spain',
+    'pt-BR': 'pt-Brazil',
+    'fr-CA': 'fr-Canada',
+    'ar-EG': 'ar-Egypt',
+    'nl-BE': 'nl-Belgium',
+    'en-GB': 'en-UnitedKingdom'
+}
+
 
 def json_rpc(method, params=None):
     """
@@ -157,94 +166,52 @@ class _WndProps(object):  # pylint: disable=no-init
 WndHomeProps = _WndProps()
 
 
-def get_kodi_audio_language(iso_format=xbmc.ISO_639_1, use_fallback=True):
+def get_kodi_audio_language(iso_format=xbmc.ISO_639_1):
     """
     Return the audio language from Kodi settings
-    WARNING: when use_fallback is False, based on Kodi settings can also return values as: 'mediadefault', 'original'
+    WARNING: Based on Kodi player settings can also return values as: 'mediadefault', 'original'
     """
     audio_language = json_rpc('Settings.GetSettingValue', {'setting': 'locale.audiolanguage'})
-    converted_lang = convert_language_iso(audio_language['value'], iso_format, use_fallback)
-    if not converted_lang:
-        if audio_language['value'] == 'default':
-            # Kodi audio language settings is set as "User interface language"
-            converted_lang = xbmc.getLanguage(iso_format, False)  # Get lang. active
-        else:
-            converted_lang = audio_language['value']
-    return converted_lang
+    if audio_language['value'] in ['mediadefault', 'original']:
+        return audio_language['value']
+    return convert_language_iso(audio_language['value'], iso_format)
 
 
 def get_kodi_subtitle_language(iso_format=xbmc.ISO_639_1):
-    """
-    Return the subtitle language from Kodi settings
-    """
+    """Return the subtitle language from Kodi settings"""
     subtitle_language = json_rpc('Settings.GetSettingValue', {'setting': 'locale.subtitlelanguage'})
     if subtitle_language['value'] == 'forced_only':
         return subtitle_language['value']
     return convert_language_iso(subtitle_language['value'], iso_format)
 
 
-def convert_language_iso(from_value, iso_format=xbmc.ISO_639_1, use_fallback=True):
+def convert_language_iso(from_value, iso_format=xbmc.ISO_639_1):
     """
-    Convert language code from an English name or three letter code (ISO 639-2) to two letter code (ISO 639-1)
-
-    :param iso_format: specify the iso format (ISO_639_1 or ISO_639_2)
-    :param use_fallback: if True when the conversion fails, is returned the current Kodi active language
+    Convert given value (English name or two/three letter code) to the specified format
+    :param iso_format: specify the iso format (two letter code ISO_639_1 or three letter code ISO_639_2)
     """
-    converted_lang = xbmc.convertLanguage(G.py2_encode(from_value), iso_format)
-    if not use_fallback:
-        return converted_lang
-    converted_lang = converted_lang if converted_lang else xbmc.getLanguage(iso_format, False)  # Get lang. active
-    return converted_lang if converted_lang else 'en' if iso_format == xbmc.ISO_639_1 else 'eng'
+    return xbmc.convertLanguage(G.py2_encode(from_value), iso_format)
 
 
 def fix_locale_languages(data_list):
-    """Replace locale code, Kodi does not understand the country code"""
-    # Get all the ISO 639-1 codes (without country)
-    verify_unofficial_lang = G.KODI_VERSION.is_major_ver('19') or not G.KODI_VERSION.is_less_version('18.7')
-    locale_list_nocountry = []
+    """Replace all the languages with the country code because Kodi does not support IETF BCP 47 standard"""
+    # Languages with the country code causes the display of wrong names in Kodi settings like
+    # es-ES as 'Spanish-Spanish', pt-BR as 'Portuguese-Breton', nl-BE as 'Dutch-Belarusian', etc
+    # and the impossibility to set them as the default audio/subtitle language
     for item in data_list:
         if item.get('isNoneTrack', False):
             continue
-        if verify_unofficial_lang and item['language'] == 'pt-BR':
-            # Unofficial ISO 639-1 Portuguese (Brazil) language code has been added to Kodi 18.7 and Kodi 19.x
-            # https://github.com/xbmc/xbmc/pull/17689
+        if item['language'] == 'pt-BR' and not G.KODI_VERSION.is_less_version('18.7'):
+            # Replace pt-BR with pb, is an unofficial ISO 639-1 Portuguese (Brazil) language code
+            # has been added to Kodi 18.7 and Kodi 19.x PR: https://github.com/xbmc/xbmc/pull/17689
             item['language'] = 'pb'
-        if len(item['language']) == 2 and not item['language'] in locale_list_nocountry:
-            locale_list_nocountry.append(item['language'])
-    # Replace the locale languages with country with a new one
-    for item in data_list:
-        if item.get('isNoneTrack', False):
-            continue
-        if len(item['language']) == 2:
-            continue
-        item['language'] = _adjust_locale(item['language'],
-                                          item['language'][0:2] in locale_list_nocountry)
-
-
-def _adjust_locale(locale_code, lang_code_without_country_exists):
-    """
-    Locale conversion helper
-    Conversion table to prevent Kodi to display
-    es-ES as Spanish - Spanish, pt-BR as Portuguese - Breton, and so on
-    Kodi issue: https://github.com/xbmc/xbmc/issues/15308
-    """
-    locale_conversion_table = {
-        'es-ES': 'es-Spain',
-        'pt-BR': 'pt-Brazil',
-        'fr-CA': 'fr-Canada',
-        'ar-EG': 'ar-Egypt',
-        'nl-BE': 'nl-Belgium',
-        'en-GB': 'en-UnitedKingdom'
-    }
-    language_code = locale_code[0:2]
-    if not lang_code_without_country_exists:
-        return language_code
-
-    if locale_code in locale_conversion_table:
-        return locale_conversion_table[locale_code]
-
-    LOG.debug('AdjustLocale - missing mapping conversion for locale: {}'.format(locale_code))
-    return locale_code
+        if len(item['language']) > 2:
+            # Replace know locale with country
+            # so Kodi will not recognize the modified country code and will show the string as it is
+            if item['language'] in LOCALE_CONV_TABLE:
+                item['language'] = LOCALE_CONV_TABLE[item['language']]
+            else:
+                LOG.error('fix_locale_languages: missing mapping conversion for locale "{}"'.format(item['language']))
 
 
 class GetKodiVersion(object):

--- a/resources/lib/services/msl/msl_utils.py
+++ b/resources/lib/services/msl/msl_utils.py
@@ -127,7 +127,7 @@ def _find_audio_data(player_state, manifest):
     """
     Find the audio downloadable id and the audio track id
     """
-    language = common.convert_language_iso(player_state['currentaudiostream']['language'], use_fallback=False)
+    language = common.convert_language_iso(player_state['currentaudiostream']['language'])
     if not language:  # If there is no language, means that is a fixed locale (fix_locale_languages in kodi_ops.py)
         language = player_state['currentaudiostream']['language']
     channels = AUDIO_CHANNELS_CONV[player_state['currentaudiostream']['channels']]

--- a/resources/lib/services/playback/am_stream_continuity.py
+++ b/resources/lib/services/playback/am_stream_continuity.py
@@ -3,6 +3,7 @@
     Copyright (C) 2017 Sebastian Golasch (plugin.video.netflix)
     Copyright (C) 2018 Caphm (original implementation module)
     Remember and restore audio stream / subtitle settings between individual episodes of a tv show or movie
+    Change the default Kodi behavior of subtitles according to user customizations
 
     SPDX-License-Identifier: MIT
     See LICENSES/MIT.md for more information.
@@ -12,10 +13,8 @@ from __future__ import absolute_import, division, unicode_literals
 import xbmc
 
 import resources.lib.common as common
-from resources.lib.common.cache_utils import CACHE_MANIFESTS
 from resources.lib.globals import G
 from resources.lib.kodi import ui
-from resources.lib.utils.esn import get_esn
 from resources.lib.utils.logging import LOG
 from .action_manager import ActionManager
 
@@ -39,35 +38,37 @@ STREAMS = {
 
 class AMStreamContinuity(ActionManager):
     """
-    Detects changes in audio / subtitle streams during playback, saves them
-    for the currently playing show and restores them on subsequent episodes.
+    Detects changes in audio / subtitle streams during playback and saves them to restore them later,
+    Change the default Kodi behavior of subtitles according to user customizations
     """
-
-    SETTING_ID = 'StreamContinuityManager_enabled'
 
     def __init__(self):
         super(AMStreamContinuity, self).__init__()
+        self.enabled = True  # By default we enable this action manager
         self.current_streams = {}
         self.sc_settings = {}
         self.player = xbmc.Player()
         self.player_state = {}
         self.resume = {}
         self.legacy_kodi_version = G.KODI_VERSION.is_major_ver('18')
-        self.kodi_only_forced_subtitles = None
+        self.is_kodi_forced_subtitles_only = None
 
     def __str__(self):
         return ('enabled={}, videoid_parent={}'
                 .format(self.enabled, self.videoid_parent))
 
     def initialize(self, data):
-        if self.videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
-            self.enabled = False
-            return
-        self.sc_settings = G.SHARED_DB.get_stream_continuity(G.LOCAL_DB.get_active_profile_guid(),
-                                                             self.videoid_parent.value, {})
-        self.kodi_only_forced_subtitles = common.get_kodi_subtitle_language() == 'forced_only'
+        self.is_kodi_forced_subtitles_only = common.get_kodi_subtitle_language() == 'forced_only'
 
     def on_playback_started(self, player_state):
+        is_enabled = G.ADDON.getSettingBool('StreamContinuityManager_enabled')
+        if is_enabled:
+            # Get user saved preferences
+            self.sc_settings = G.SHARED_DB.get_stream_continuity(G.LOCAL_DB.get_active_profile_guid(),
+                                                                 self.videoid_parent.value, {})
+        else:
+            # Disable on_tick activity to check changes of settings
+            self.enabled = False
         if (not self.legacy_kodi_version and
                 player_state.get(STREAMS['subtitle']['current']) is None and
                 player_state.get('currentvideostream') is None):
@@ -81,19 +82,26 @@ class AMStreamContinuity(ActionManager):
             return
         xbmc.sleep(500)  # Wait for slower systems
         self.player_state = player_state
-        if self.kodi_only_forced_subtitles and G.ADDON.getSettingBool('forced_subtitle_workaround')\
-           and self.sc_settings.get('subtitleenabled') is None:
-            # Use the forced subtitle workaround if enabled
-            # and if user did not change the subtitle setting
-            self._show_only_forced_subtitle()
+        # If the user has not changed the subtitle settings
+        if self.sc_settings.get('subtitleenabled') is None:
+            # Ensures the display of forced subtitles only with the audio language set
+            if G.ADDON.getSettingBool('show_forced_subtitles_only'):
+                if self.legacy_kodi_version:
+                    self._ensure_forced_subtitle_only_kodi18()
+                else:
+                    self._ensure_forced_subtitle_only()
+            # Ensure in any case to show the regular subtitles when the preferred audio language is not available
+            if not self.legacy_kodi_version and G.ADDON.getSettingBool('show_subtitles_miss_audio'):
+                self._ensure_subtitles_no_audio_available()
         for stype in sorted(STREAMS):
-            # Save current stream info from the player to local dict
+            # Save current stream setting from the Kodi player to the local dict
             self._set_current_stream(stype, player_state)
-            # Restore the user choice
+            # Apply the chosen stream setting to Kodi player and update the local dict
             self._restore_stream(stype)
-        # It is mandatory to wait at least 1 second to allow the Kodi system to update the values
-        # changed by restore, otherwise when _on_tick is executed it will save twice unnecessarily
-        xbmc.sleep(1000)
+        if is_enabled:
+            # It is mandatory to wait at least 1 second to allow the Kodi system to update the values
+            # changed by restore, otherwise when on_tick is executed it will save twice unnecessarily
+            xbmc.sleep(1000)
 
     def on_tick(self, player_state):
         self.player_state = player_state
@@ -197,10 +205,8 @@ class AMStreamContinuity(ActionManager):
         # is_original = stored_stream.get('isoriginal')
         is_impaired = stored_stream.get('isimpaired')
         is_forced = stored_stream.get('isforced')
-
         # Filter streams by language
         streams = _filter_streams(streams, 'language', language)
-
         # Filter streams by number of channel (on audio stream)
         if channels:
             for n_channels in range(channels, 3, -1):  # Auto fallback on fewer channels
@@ -208,7 +214,6 @@ class AMStreamContinuity(ActionManager):
                 if results:
                     streams = results
                     break
-
         # Find the impaired stream
         if is_impaired:
             for stream in streams:
@@ -217,78 +222,140 @@ class AMStreamContinuity(ActionManager):
         else:
             # Remove impaired streams
             streams = _filter_streams(streams, 'isimpaired', False)
-
         # Find the forced stream (on subtitle stream)
         if is_forced:
             for stream in streams:
                 if stream.get('isforced'):
                     return stream['index']
-            # Forced stream not found, then fix Kodi bug if user chose to apply the workaround
-            # Kodi bug???:
-            # If the kodi player is set with "forced only" subtitle setting, Kodi use this behavior:
-            # 1) try to select forced subtitle that matches audio language
-            # 2) if missing the forced subtitle in language, then
-            #    Kodi try to select: The first "forced" subtitle or the first "regular" subtitle
-            #    that can respect the chosen language or not, depends on the available streams
-            # So can cause a wrong subtitle language or in a permanent display of subtitles!
-            # This does not reflect the setting chosen in the Kodi player and is very annoying!
-            # There is no other solution than to disable the subtitles manually.
-            if G.ADDON.getSettingBool('forced_subtitle_workaround') and \
-               self.kodi_only_forced_subtitles:
-                # Note: this change is temporary so not stored to db by sc_settings setter
-                self.sc_settings.update({'subtitleenabled': False})
-                return None
-        else:
-            # Remove forced streams
-            streams = _filter_streams(streams, 'isforced', False)
-
+            # Note: this change is temporary so not stored to db by sc_settings setter
+            self.sc_settings.update({'subtitleenabled': False})
+            return None
+        # Remove forced streams
+        streams = _filter_streams(streams, 'isforced', False)
         # if the language is not missing there should be at least one result
         return streams[0]['index'] if streams else None
 
-    def _show_only_forced_subtitle(self):
-        # Forced stream not found, then fix Kodi bug if user chose to apply the workaround
-        # Kodi bug???:
-        # If the kodi player is set with "forced only" subtitle setting, Kodi use this behavior:
-        # 1) try to select forced subtitle that matches audio language
-        # 2) if missing the forced subtitle in language, then
-        #    Kodi try to select: The first "forced" subtitle or the first "regular" subtitle
-        #    that can respect the chosen language or not, depends on the available streams
-        # So can cause a wrong subtitle language or in a permanent display of subtitles!
-        # This does not reflect the setting chosen in the Kodi player and is very annoying!
-        # There is no other solution than to disable the subtitles manually.
-        if self.legacy_kodi_version:
-            # --- ONLY FOR KODI VERSION 18 ---
-            # NOTE: With Kodi 18 it is not possible to read the properties of the streams
-            # so the only possible way is to read the data from the manifest file
-            audio_language = common.get_kodi_audio_language()
-            cache_identifier = get_esn() + '_' + self.videoid.value
-            manifest_data = G.CACHE.get(CACHE_MANIFESTS, cache_identifier)
-            common.fix_locale_languages(manifest_data['timedtexttracks'])
-            if not any(text_track.get('isForcedNarrative', False) is True and
-                       text_track['language'] == audio_language
-                       for text_track in manifest_data['timedtexttracks']):
-                self.sc_settings.update({'subtitleenabled': False})
-        else:
-            # --- ONLY FOR KODI VERSION 19 ---
-            audio_language = common.get_kodi_audio_language(iso_format=xbmc.ISO_639_2, use_fallback=False)
-            if audio_language == 'mediadefault':
-                # Find the language of the default audio track
-                audio_list = self.player_state.get(STREAMS['audio']['list'])
-                for audio_track in audio_list:
-                    if audio_track['isdefault']:
-                        audio_language = audio_track['language']
-                        break
-            player_stream = self.player_state.get(STREAMS['subtitle']['current'])
-            if not player_stream:
+    def _ensure_forced_subtitle_only_kodi18(self):
+        """Ensures the display of forced subtitles only with the audio language set [KODI 18]"""
+        # With Kodi 18 it is not possible to read the properties of the player streams,
+        # so the only possible way is to read the data from the manifest file
+        from resources.lib.common.cache_utils import CACHE_MANIFESTS
+        from resources.lib.utils.esn import get_esn
+        # Get the manifest
+        cache_identifier = get_esn() + '_' + self.videoid.value
+        manifest = G.CACHE.get(CACHE_MANIFESTS, cache_identifier)
+        common.fix_locale_languages(manifest['timedtexttracks'])
+        # Get the language
+        audio_language = common.get_kodi_audio_language()
+        if audio_language == 'mediadefault':
+            # Netflix do not have a "Media default" track then we rely on the language of current nf profile,
+            # although due to current Kodi locale problems could be not always accurate.
+            profile_language_code = G.LOCAL_DB.get_profile_config('language')
+            audio_language = profile_language_code[0:2]
+        if audio_language == 'original':
+            # Find the language of the original audio track
+            stream = next((audio_track for audio_track in manifest['audio_tracks']
+                           if audio_track['isNative']), None)
+            if not stream:
                 return
-            if audio_language == 'original':
-                # Do nothing
-                is_language_appropriate = True
+            audio_language = stream['language']
+        # Check in the manifest if there is a forced subtitle in the specified language
+        if not any(text_track.get('isForcedNarrative', False)
+                   and text_track['language'] == audio_language
+                   for text_track in manifest['timedtexttracks']):
+            self.sc_settings.update({'subtitleenabled': False})
+
+    def _ensure_forced_subtitle_only(self):
+        """Ensures the display of forced subtitles only with the audio language set"""
+        # When the audio language in Kodi player is set e.g. to 'Italian', and you try to play a video
+        # without Italian audio language, Kodi choose another language available e.g. English,
+        # this will also be reflected on the subtitles that which will be shown in English language,
+        # but the subtitles may be available in Italian or the user may not want to view them in other languages.
+        # Get current subtitle stream
+        player_stream = self.player_state.get(STREAMS['subtitle']['current'])
+        if not player_stream:
+            return
+        # Get current audio language
+        audio_language = self._get_current_audio_language()
+        if player_stream['isforced'] and player_stream['language'] == audio_language:
+            return
+        subtitles_list = self.player_state.get(STREAMS['subtitle']['list'])
+        if not player_stream['language'] == audio_language:
+            # The current subtitle is not forced or forced but not in the preferred audio language
+            # Try find a forced subtitle in the preferred audio language
+            stream = next((subtitle_track for subtitle_track in subtitles_list
+                           if subtitle_track['language'] == audio_language
+                           and subtitle_track['isforced']),
+                          None)
+            if stream:
+                # Set the forced subtitle
+                self.sc_settings.update({'subtitleenabled': True})
+                self.sc_settings.update({'subtitle': stream})
             else:
-                is_language_appropriate = player_stream['language'] == audio_language
-            # Check if the current stream is forced and with an appropriate subtitle language
-            if not player_stream['isforced'] or not is_language_appropriate:
+                # Disable the subtitles
                 self.sc_settings.update({'subtitleenabled': False})
+
+    def _ensure_subtitles_no_audio_available(self):
+        """Ensure in any case to show the regular subtitles when the preferred audio language is not available"""
+        # Get current subtitle stream
+        player_stream = self.player_state.get(STREAMS['subtitle']['current'])
+        if not player_stream:
+            return
+        # Get current audio language
+        audio_language = self._get_current_audio_language()
+        audio_list = self.player_state.get(STREAMS['audio']['list'])
+        stream = self._find_subtitle_stream(audio_language, audio_list)
+        if stream:
+            self.sc_settings.update({'subtitleenabled': True})
+            self.sc_settings.update({'subtitle': stream})
+
+    def _find_subtitle_stream(self, audio_language, audio_list):
+        # Check if there is an audio track available in the preferred audio language
+        if not any(audio_track['language'] == audio_language for audio_track in audio_list):
+            # No audio available for the preferred audio language,
+            # then try find a regular subtitle in the preferred audio language
+            subtitles_list = self.player_state.get(STREAMS['subtitle']['list'])
+            # Take in account if a user have enabled Kodi impaired subtitles preference
+            is_prefer_impaired = common.json_rpc('Settings.GetSettingValue',
+                                                 {'setting': 'accessibility.subhearing'}).get('value')
+            stream = next((subtitle_track for subtitle_track in subtitles_list
+                           if subtitle_track['language'] == audio_language
+                           and not subtitle_track['isforced']
+                           and subtitle_track['isimpaired']),
+                          None) if is_prefer_impaired else None
+            if not stream:
+                stream = next((subtitle_track for subtitle_track in subtitles_list
+                               if subtitle_track['language'] == audio_language
+                               and not subtitle_track['isforced']
+                               and not subtitle_track['isimpaired']),
+                              None)
+            return stream
+        return None
+
+    def _get_current_audio_language(self):
+        # Get current audio language
+        audio_list = self.player_state.get(STREAMS['audio']['list'])
+        audio_language = common.get_kodi_audio_language(iso_format=xbmc.ISO_639_2)
+        if audio_language == 'mediadefault':
+            # Netflix do not have a "Media default" track then we rely on the language of current nf profile,
+            # although due to current Kodi locale problems could be not always accurate.
+            profile_language_code = G.LOCAL_DB.get_profile_config('language')
+            audio_language = common.convert_language_iso(profile_language_code[0:2], xbmc.ISO_639_2)
+        if audio_language == 'original':
+            # Find the language of the original audio track
+            stream = next((audio_track for audio_track in audio_list if audio_track['isoriginal']), None)
+            audio_language = stream['language']
+        elif G.ADDON.getSettingBool('prefer_alternative_lang'):
+            # Get the alternative language code
+            # Here we have only the language code without country code, we do not know the country code to be used,
+            # usually there are only two tracks with the same language and different countries,
+            # then we try to find the language with the country code
+            two_letter_lang_code = common.convert_language_iso(audio_language)
+            stream = next((audio_track for audio_track in audio_list
+                           if audio_track['language'].startswith(two_letter_lang_code + '-')), None)
+            if stream:
+                audio_language = stream['language']
+        return audio_language
 
     def _is_stream_value_equal(self, stream_a, stream_b):
         if self.legacy_kodi_version:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -100,12 +100,14 @@
     <setting id="viewmodeexportedid" type="number" label="30143" visible="eq(-1,1) + eq(-20,true)" enable="eq(-20,true)" subsetting="true"/>
   </category>
   <category label="30078"><!--Playback-->
-    <setting id="BookmarkManager_enabled" type="bool" label="30083" visible="false" default="true"/>
-    <setting id="StreamContinuityManager_enabled" type="bool" label="30082" default="true"/>
+    <setting id="StreamContinuityManager_enabled" type="bool" label="30082" default="true" />
+    <setting id="show_forced_subtitles_only" type="bool" label="30083" default="false"/>
+    <setting id="show_subtitles_miss_audio" type="bool" label="30181" default="false" visible="!String.StartsWith(System.BuildVersion,18)" />
+    <setting id="prefer_alternative_lang" type="bool" label="30500" default="false" visible="!String.StartsWith(System.BuildVersion,18)" />
+    <setting id="prefer_audio_stereo" type="bool" label="30501" default="false" />
     <setting id="SectionSkipper_enabled" type="bool" label="30075" default="true"/>
     <setting id="auto_skip_credits" type="bool" label="30079" default="false" visible="eq(-1,true)" subsetting="true"/>
     <setting id="pause_on_skip" type="bool" label="30080" default="false" visible="eq(-1,true)" subsetting="true"/>
-    <setting id="forced_subtitle_workaround" type="bool" label="30181" default="true" />
     <setting label="30049" type="lsep"/><!--Library-->
     <setting id="ResumeManager_enabled" type="bool" label="30176" default="true"/>
     <setting id="ResumeManager_dialog" type="bool" label="30177" default="true" visible="eq(-1,true)" subsetting="true"/>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Over time some problems have been fixed the language selection, but it has never been optimal, the cases of use are many so i summarize the hot spots.

Mainly now are managed in the best way audio/subtitles tracks that will be set as default, to allow Kodi to autonomously select the appropriate track/language.
This allowed to remove many old workarounds that in particular cases caused wrong behaviors like disabling subtitles or select wrong language.

Main changes:
- Add support to Kodi player audio setting "Media default"
This case will be used to automatically set the audio language based on the language of the selected Netflix profile
- Better support to Kodi player audio/subtitles setting "Original"
- Add option to force the display subtitles only with the audio language set
One use case example:
When the audio language in Kodi player is set e.g. to 'Italian', and you try to play a video
without Italian audio language, Kodi choose another language available e.g. English,
this will also be reflected on the subtitles that which will be shown in English language,
but the subtitles may be available in Italian or the user may not want to view them in other languages.
- [KODI 19 ONLY] Add option to always show regular subtitles when the preferred audio language is not available
Use case example:
When Kodi player has subtitles setting set as "Forced only" and the played video doesn't have your preferred audio language available, but the regular subtitle yes, then show the subtitles.
- [KODI 19 ONLY] Add option to prefer select audio/subtitles with country code
Use case example:
You are playing a video that has audio tracks in the same language but in two different countries e.g.:
Audio track: Spanish
Audio track: Spanish-Spain
If this setting will be enabled, will give priority to automatically select the language with country code, so "Spanish-Spain" instead "Spanish" (same thing with subtitles)
- Add option to prefer stereo tracks instead multichannels audio
Allows you to use Dolby stereo audio tracks, instead of disable the dolby audio profile

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
