### PR TITLE
Manage manually the timeout for HTTP requests

### DIFF
--- a/resources/lib/common/exceptions.py
+++ b/resources/lib/common/exceptions.py
@@ -21,6 +21,10 @@ class HttpError401(Exception):
     """The request has returned http error 401 unauthorized for url ..."""
 
 
+class HttpErrorTimeout(Exception):
+    """The request has raised timeout"""
+
+
 class WebsiteParsingError(Exception):
     """Parsing info from the Netflix Website failed"""
 

--- a/resources/lib/services/msl/msl_handler.py
+++ b/resources/lib/services/msl/msl_handler.py
@@ -24,7 +24,7 @@ from resources.lib.utils.logging import LOG, measure_exec_time_decorator
 from .converter import convert_to_dash
 from .events_handler import EventsHandler
 from .msl_requests import MSLRequests
-from .msl_utils import ENDPOINTS, display_error_info, MSL_DATA_FILENAME
+from .msl_utils import ENDPOINTS, display_error_info, MSL_DATA_FILENAME, create_req_params
 from .profiles import enabled_profiles
 
 try:  # Python 2
@@ -223,7 +223,7 @@ class MSLHandler(object):
             #   then when ISA perform the license callback we replace it with the fresh license challenge data.
             params['challenge'] = self.manifest_challenge
 
-        endpoint_url = ENDPOINTS['manifest'] + '?reqAttempt=1&reqPriority=0&reqName=prefetch/manifest'
+        endpoint_url = ENDPOINTS['manifest'] + create_req_params(0, 'prefetch/manifest')
         manifest = self.msl_requests.chunked_request(endpoint_url,
                                                      self.msl_requests.build_request_data('/manifest', params),
                                                      esn,
@@ -257,7 +257,7 @@ class MSLHandler(object):
             'xid': xid
         }]
         self.manifest_challenge = challenge
-        endpoint_url = ENDPOINTS['license'] + '?reqAttempt=1&reqPriority=0&reqName=prefetch/license'
+        endpoint_url = ENDPOINTS['license'] + create_req_params(0, 'prefetch/license')
         response = self.msl_requests.chunked_request(endpoint_url,
                                                      self.msl_requests.build_request_data(self.last_license_url,
                                                                                           params,
@@ -281,7 +281,8 @@ class MSLHandler(object):
         # playback, and only the first time after a switch,
         # in the response you can also understand if the msl switch has worked
         LOG.debug('Requesting bind events')
-        response = self.msl_requests.chunked_request(ENDPOINTS['manifest'],
+        endpoint_url = ENDPOINTS['manifest'] + create_req_params(20, 'bind')
+        response = self.msl_requests.chunked_request(endpoint_url,
                                                      self.msl_requests.build_request_data('/bind', {}),
                                                      get_esn(),
                                                      disable_msl_switch=False)
@@ -308,7 +309,8 @@ class MSLHandler(object):
                 'echo': 'drmSessionId'
             }]
 
-            response = self.msl_requests.chunked_request(ENDPOINTS['license'],
+            endpoint_url = ENDPOINTS['license'] + create_req_params(10, 'release/license')
+            response = self.msl_requests.chunked_request(endpoint_url,
                                                          self.msl_requests.build_request_data('/bundle', params),
                                                          get_esn())
             LOG.debug('License release response: {}', response)

--- a/resources/lib/services/msl/msl_utils.py
+++ b/resources/lib/services/msl/msl_utils.py
@@ -28,6 +28,11 @@ try:  # Python 2
 except NameError:  # Python 3
     unicode = str  # pylint: disable=redefined-builtin
 
+try:  # Python 2
+    from urllib import urlencode
+except ImportError:  # Python 3
+    from urllib.parse import urlencode
+
 CHROME_BASE_URL = 'https://www.netflix.com/nq/msl_v1/cadmium/'
 # 16/10/2020 There is a new api endpoint to now used only for events/logblobs
 CHROME_PLAYAPI_URL = 'https://www.netflix.com/msl/playapi/cadmium/'
@@ -213,3 +218,22 @@ def generate_logblobs_params():
     blobs_dump = json.dumps(blobs_container)
     blobs_dump = blobs_dump.replace('"', '\"').replace(' ', '').replace('#', ' ')
     return {'logblobs': blobs_dump}
+
+
+def create_req_params(req_priority, req_name):
+    """Create the params for the POST request"""
+    # Used list of tuple in order to preserve the params order
+    # Will result something like:
+    # ?reqAttempt=&reqPriority=0&reqName=events/engage&clienttype=akira&uiversion=vdeb953cf&browsername=chrome&browserversion=84.0.4147.136&osname=windows&osversion=10.0
+    params = [
+        ('reqAttempt', ''),  # Will be populated by _post() in msl_requests.py
+        ('reqPriority', req_priority),
+        ('reqName', req_name),
+        ('clienttype', 'akira'),
+        ('uiversion', G.LOCAL_DB.get_value('build_identifier', '', table=TABLE_SESSION)),
+        ('browsername', 'chrome'),
+        ('browserversion', G.LOCAL_DB.get_value('browser_info_version', '', table=TABLE_SESSION).lower()),
+        ('osname', G.LOCAL_DB.get_value('browser_info_os_name', '', table=TABLE_SESSION).lower()),
+        ('osversion', G.LOCAL_DB.get_value('browser_info_os_version', '', table=TABLE_SESSION))
+    ]
+    return '?' + urlencode(params)


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Usually a server should automatically specify a timeout for requests, but lately for some users this doesn't happen anymore.
When happen the addon not works anymore and become unresponsive, this because the HTTP request remains on hold and indefinitely blocking the add-on service.
As workaround has been set the HTTP request timeout manually and managed in some way the ReadTimeout error.

The cause of this behavior is currently unknown,
could also be a temporary problem of network or their server

I'm not sure that the timeout set is suitable for all cases, the efficiency of HTTP connection and HTTP response depends on the network and for each endpoint of each server.

Ref. Issue https://github.com/CastagnaIT/plugin.video.netflix/issues/914

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
