### PR TITLE
Misc fixes to audio/subtitles language code with country code

### DIFF
--- a/resources/lib/services/playback/am_stream_continuity.py
+++ b/resources/lib/services/playback/am_stream_continuity.py
@@ -10,6 +10,8 @@
 """
 from __future__ import absolute_import, division, unicode_literals
 
+import copy
+
 import xbmc
 
 import resources.lib.common as common
@@ -41,7 +43,14 @@ class AMStreamContinuity(ActionManager):
     Detects changes in audio / subtitle streams during playback and saves them to restore them later,
     Change the default Kodi behavior of subtitles according to user customizations
     """
-
+    # How test/debug these features:
+    # First thing (if not needed to your debug) disable "Remember audio / subtitle preferences" feature.
+    # When you play a video, and you try to change audio/subtitles tracks, Kodi may save this change in his database,
+    # the same thing happen when you use/enable the features of this module.
+    # So when the next time you play the SAME video may invalidate these features, because Kodi restore saved settings.
+    # To test multiple times these features on the SAME video, (e.g.),
+    # you must delete, every time, the file /Kodi/userdata/Database/MyVideosXXX.db, or,
+    # if you are able you can delete in realtime the data in the 'settings' table of db file.
     def __init__(self):
         super(AMStreamContinuity, self).__init__()
         self.enabled = True  # By default we enable this action manager
@@ -52,6 +61,8 @@ class AMStreamContinuity(ActionManager):
         self.resume = {}
         self.legacy_kodi_version = G.KODI_VERSION.is_major_ver('18')
         self.is_kodi_forced_subtitles_only = None
+        self.is_prefer_sub_impaired = None
+        self.is_prefer_audio_impaired = None
 
     def __str__(self):
         return ('enabled={}, videoid_parent={}'
@@ -59,6 +70,10 @@ class AMStreamContinuity(ActionManager):
 
     def initialize(self, data):
         self.is_kodi_forced_subtitles_only = common.get_kodi_subtitle_language() == 'forced_only'
+        self.is_prefer_sub_impaired = common.json_rpc('Settings.GetSettingValue',
+                                                      {'setting': 'accessibility.subhearing'}).get('value')
+        self.is_prefer_audio_impaired = common.json_rpc('Settings.GetSettingValue',
+                                                        {'setting': 'accessibility.audiovisual'}).get('value')
 
     def on_playback_started(self, player_state):
         is_enabled = G.ADDON.getSettingBool('StreamContinuityManager_enabled')
@@ -84,6 +99,11 @@ class AMStreamContinuity(ActionManager):
         self.player_state = player_state
         # If the user has not changed the subtitle settings
         if self.sc_settings.get('subtitleenabled') is None:
+            # Copy player state to restore it after, or the changes will affect the _restore_stream()
+            _player_state_copy = copy.deepcopy(player_state)
+            # Force selection of the audio/subtitles language with country code
+            if not self.legacy_kodi_version and G.ADDON.getSettingBool('prefer_alternative_lang'):
+                self._select_lang_with_country_code()
             # Ensures the display of forced subtitles only with the audio language set
             if G.ADDON.getSettingBool('show_forced_subtitles_only'):
                 if self.legacy_kodi_version:
@@ -93,6 +113,7 @@ class AMStreamContinuity(ActionManager):
             # Ensure in any case to show the regular subtitles when the preferred audio language is not available
             if not self.legacy_kodi_version and G.ADDON.getSettingBool('show_subtitles_miss_audio'):
                 self._ensure_subtitles_no_audio_available()
+            player_state = _player_state_copy
         for stype in sorted(STREAMS):
             # Save current stream setting from the Kodi player to the local dict
             self._set_current_stream(stype, player_state)
@@ -235,6 +256,62 @@ class AMStreamContinuity(ActionManager):
         # if the language is not missing there should be at least one result
         return streams[0]['index'] if streams else None
 
+    def _select_lang_with_country_code(self):
+        """Force selection of the audio/subtitles language with country code"""
+        # If Kodi Player audio language is not set as "mediadefault" the language with country code for
+        # audio/subtitles, will never be selected automatically, then we try to do this manually.
+        audio_language = self._get_current_audio_language()
+        if '-' not in audio_language:
+            # There is no audio language with country code or different settings have been chosen
+            return
+        # Audio side
+        if common.get_kodi_audio_language() not in ['mediadefault', 'original']:
+            audio_list = self.player_state.get(STREAMS['audio']['list'])
+            stream = None
+            if self.is_prefer_audio_impaired:
+                stream = next((audio_track for audio_track in audio_list
+                               if audio_track['language'] == audio_language
+                               and audio_track['isimpaired']
+                               and audio_track['isdefault']),  # The default track can change is user choose 2ch as def
+                              None)
+            if not stream:
+                stream = next((audio_track for audio_track in audio_list
+                               if audio_track['language'] == audio_language
+                               and not audio_track['isimpaired']
+                               and audio_track['isdefault']),  # The default track can change is user choose 2ch as def
+                              None)
+            if stream:
+                self.sc_settings.update({'audio': stream})
+                # We update the current player state data to avoid wrong behaviour with features executed after
+                self.player_state[STREAMS['audio']['current']] = stream
+        # Subtitles side
+        subtitle_list = self.player_state.get(STREAMS['subtitle']['list'])
+        if not any(subtitle_track for subtitle_track in subtitle_list
+                   if subtitle_track['language'].startswith(audio_language[:2] + '-')):
+            self.sc_settings.update({'subtitleenabled': False})
+            return
+        if self.is_kodi_forced_subtitles_only:
+            subtitle_language = audio_language
+        else:
+            # Get the subtitles language set in Kodi Player setting
+            subtitle_language = common.get_kodi_subtitle_language()
+            # Get the alternative language code
+            # Here we have only the language code without country code, we do not know the country code to be used,
+            # usually there are only two tracks with the same language and different countries,
+            # then we try to find the language with the country code
+            _stream = next((subtitle_track for subtitle_track in subtitle_list
+                            if subtitle_track['language'].startswith(subtitle_language + '-')), None)
+            if _stream:
+                subtitle_language = _stream['language']
+        stream_sub = self._find_subtitle_stream(subtitle_language, self.is_kodi_forced_subtitles_only)
+        if stream_sub:
+            self.sc_settings.update({'subtitleenabled': True})
+            self.sc_settings.update({'subtitle': stream_sub})
+            # We update the current player state data to avoid wrong behaviour with features executed after
+            self.player_state[STREAMS['subtitle']['current']] = stream_sub
+        else:
+            self.sc_settings.update({'subtitleenabled': False})
+
     def _ensure_forced_subtitle_only_kodi18(self):
         """Ensures the display of forced subtitles only with the audio language set [KODI 18]"""
         # With Kodi 18 it is not possible to read the properties of the player streams,
@@ -304,33 +381,35 @@ class AMStreamContinuity(ActionManager):
         # Get current audio language
         audio_language = self._get_current_audio_language()
         audio_list = self.player_state.get(STREAMS['audio']['list'])
-        stream = self._find_subtitle_stream(audio_language, audio_list)
-        if stream:
-            self.sc_settings.update({'subtitleenabled': True})
-            self.sc_settings.update({'subtitle': stream})
-
-    def _find_subtitle_stream(self, audio_language, audio_list):
+        stream = None
         # Check if there is an audio track available in the preferred audio language
         if not any(audio_track['language'] == audio_language for audio_track in audio_list):
             # No audio available for the preferred audio language,
             # then try find a regular subtitle in the preferred audio language
-            subtitles_list = self.player_state.get(STREAMS['subtitle']['list'])
-            # Take in account if a user have enabled Kodi impaired subtitles preference
-            is_prefer_impaired = common.json_rpc('Settings.GetSettingValue',
-                                                 {'setting': 'accessibility.subhearing'}).get('value')
+            stream = self._find_subtitle_stream(audio_language, audio_list)
+        if stream:
+            self.sc_settings.update({'subtitleenabled': True})
+            self.sc_settings.update({'subtitle': stream})
+
+    def _find_subtitle_stream(self, language, is_forced=False):
+        # Take in account if a user have enabled Kodi impaired subtitles preference
+        # but only without forced setting (same Kodi player behaviour)
+        is_prefer_impaired = self.is_prefer_sub_impaired and not is_forced
+        subtitles_list = self.player_state.get(STREAMS['subtitle']['list'])
+        stream = None
+        if is_prefer_impaired:
             stream = next((subtitle_track for subtitle_track in subtitles_list
-                           if subtitle_track['language'] == audio_language
-                           and not subtitle_track['isforced']
+                           if subtitle_track['language'] == language
+                           and subtitle_track['isforced'] == is_forced
                            and subtitle_track['isimpaired']),
-                          None) if is_prefer_impaired else None
-            if not stream:
-                stream = next((subtitle_track for subtitle_track in subtitles_list
-                               if subtitle_track['language'] == audio_language
-                               and not subtitle_track['isforced']
-                               and not subtitle_track['isimpaired']),
-                              None)
-            return stream
-        return None
+                          None)
+        if not stream:
+            stream = next((subtitle_track for subtitle_track in subtitles_list
+                           if subtitle_track['language'] == language
+                           and subtitle_track['isforced'] == is_forced
+                           and not subtitle_track['isimpaired']),
+                          None)
+        return stream
 
     def _get_current_audio_language(self):
         # Get current audio language


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
When i have made the previous PR #933 
I didn't realize that Kodi have a different behaviour when the Kodi player "preferred audio language" is set to "Media default"
or a language name.

if you set Kodi player with "preferred audio language" to a language name instead of "Media default",
the "Prefer the audio/subtitle language with coutry code" option, not works anymore, unfurnately this happen Kodi 18 and 19, because Kodi no longer looks at defaults tracks even if they have the same left language code

To fix this case, to Kodi 19 i have implemented the track selection via code,
but on Kodi 18 is not possible to fix the only way is revert the changes to the old wrong code behaviour...

The module am_stream_continuity.py need to be cleaned is getting too confusing
will be done shortly, when the Leia branch will be created,
the new Leia branch will only receive critical updates

This PR fix also the missing default audio track for impaired

Ref. #962 
### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
