### PR TITLE
Version bump (1.12.0) - End of add-on development on Kodi 18.x

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.netflix" name="Netflix" version="1.11.0" provider-name="libdev + jojo + asciidisco + caphm + castagnait">
+<addon id="plugin.video.netflix" name="Netflix" version="1.12.0" provider-name="libdev + jojo + asciidisco + caphm + castagnait">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
     <import addon="script.module.addon.signals" version="0.0.3"/>
@@ -85,20 +85,22 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=329767</forum>
     <source>https://github.com/CastagnaIT/plugin.video.netflix</source>
     <news>
-v1.11.0 (2020-11-14)
-- Reworked Audio/Subtitles language features
-  - Add support to Kodi player audio setting "Media default" (use NF profile language)
-  - Add setting to force the display subtitles only with the audio language set
-  - Add setting to always show subtitles when the preferred audio language is not available (Kodi 19 only)
-  - Add setting to prefer audio/subtitles with country code (Kodi 19 only)
-  - Add setting to prefer stereo audio tracks (instead of multichannels)
-- Add check for video availability
-- Add support to NFAuthentication for MacOS
-- Add workaround to HTTP connection problem blocking the add-on service
-- Fixed wrong resume time after manual seek (when nf sync enabled)
-- Fixed login/addon open error due to json parsing error
-- Updated translations it, jp, kr, tr, gr, ro, fr, hu, pl, de, zh-cn, pt-br
-- Others minor fixes
+v1.12.0 (2020-12-13)
+- >> END OF THE ADD-ON DEVELOPMENT ON KODI 18.x
+- >> ON KODI 18.x THE ADD-ON WILL RECEIVE ONLY BUG FIX OR MINOR CHANGES
+- Add more options to force Widevine L3 (android)
+- Improved errors messages to resolve:
+  - This title is not available to watch instantly
+  - Request failed validation during key exchange
+- Reverted "reworked Audio/Subtitles language features" on Kodi 18
+- Fix missing default audio track for impaired (Kodi 19)
+- Fixed "Prefer audio/subtitles language with country code" (Kodi 19)
+- Parental control moved to profiles list context menu
+- Fixed ESN generation with modelgroup
+- Fixed build_media_tag exception due to video pause
+- Blocked profile switching while playing, can cause issues
+- Managed wrong password case on login that caused http error 500
+- Updated translations it, de, gr, pt-br, hu, ro, es, jp, kr, fr
     </news>
   </extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,21 @@
+v1.12.0 (2020-12-13)
+- >> END OF THE ADD-ON DEVELOPMENT ON KODI 18.x
+- >> ON KODI 18.x THE ADD-ON WILL RECEIVE ONLY BUG FIX OR MINOR CHANGES
+- Add more options to force Widevine L3 (android)
+- Improved errors messages to resolve:
+  - This title is not available to watch instantly
+  - Request failed validation during key exchange
+- Reverted "reworked Audio/Subtitles language features" on Kodi 18
+- Fix missing default audio track for impaired (Kodi 19)
+- Fixed "Prefer audio/subtitles language with country code" (Kodi 19)
+- Parental control moved to profiles list context menu
+- Fixed ESN generation with modelgroup
+- Fixed build_media_tag exception due to video pause
+- Blocked profile switching while playing, can cause issues
+- Managed wrong password case on login that caused http error 500
+- Updated translations it, de, gr, pt-br, hu, ro, es, jp, kr, fr
+
+
 v1.11.0 (2020-11-14)
 - Reworked Audio/Subtitles language features
   - Add support to Kodi player audio setting "Media default" (use NF profile language)


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
## NOTICE: This version bump marks the end of add-on development on Kodi 18.x

**What means, what you should expect now on Kodi 18.x ?**
- Only critical updates will be applied (so bug fixing or minor changes to restore add-on functionality)
- Critical updates _that require too much work_ to the source code will _not_ be done directly from maintainer, but a backport (from master branch) made by other developers can be accepted
- The backport of new features or changes in the existing features developed in the add-on for Kodi 19 version, could be accepted only if they are maintained by other developers, the maintainer will not provide support to fix any side effects or backporting errors

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
