### PR TITLE
Fixed problems with HTTP requests

### DIFF
--- a/resources/lib/common/exceptions.py
+++ b/resources/lib/common/exceptions.py
@@ -20,10 +20,6 @@ class HttpError401(Exception):
     """The request has returned http error 401 unauthorized for url ..."""
 
 
-class HttpErrorTimeout(Exception):
-    """The request has raised timeout"""
-
-
 class WebsiteParsingError(Exception):
     """Parsing info from the Netflix Website failed"""
 

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -12,7 +12,7 @@ from xbmc import getCondVisibility, Monitor, getInfoLabel
 
 from resources.lib.common.exceptions import (HttpError401, InputStreamHelperError, MbrStatusNeverMemberError,
                                              MbrStatusFormerMemberError, MissingCredentialsError, LoginError,
-                                             NotLoggedInError, InvalidPathError, BackendNotReady, HttpErrorTimeout)
+                                             NotLoggedInError, InvalidPathError, BackendNotReady)
 from resources.lib.common import check_credentials, get_local_string, WndHomeProps
 from resources.lib.globals import G
 from resources.lib.upgrade_controller import check_addon_upgrade
@@ -37,12 +37,11 @@ def catch_exceptions_decorator(func):
                            ('The operation has been cancelled.[CR]'
                             'InputStream Helper has generated an internal error:[CR]{}[CR][CR]'
                             'Please report it to InputStream Helper github.'.format(exc)))
-        except (HttpError401, HttpErrorTimeout) as exc:
-            # HttpError401: This is a generic error, can happen when the http request for some reason has failed.
+        except HttpError401 as exc:
+            # This is a generic error, can happen when the http request for some reason has failed.
             # Known causes:
             # - Possible change of data format or wrong data in the http request (also in headers/params)
             # - Some current nf session data are not more valid (authURL/cookies/...)
-            # HttpErrorTimeout: This error is raised by Requests ReadTimeout error, unknown causes
             from resources.lib.kodi.ui import show_ok_dialog
             show_ok_dialog(get_local_string(30105),
                            ('There was a communication problem with Netflix.[CR]'

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -105,7 +105,7 @@ class EventsHandler(threading.Thread):
                                                                'events/{}'.format(event))
         try:
             response = self.chunked_request(endpoint_url, event.request_data, get_esn(),
-                                            disable_msl_switch=False, retry_all_exceptions=True)
+                                            disable_msl_switch=False)
             # Malformed/wrong content in requests are ignored without returning error feedback in the response
             event.set_response(response)
         except Exception as exc:  # pylint: disable=broad-except

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -15,7 +15,6 @@ import time
 import zlib
 
 import requests
-from requests import exceptions
 
 import resources.lib.common as common
 from resources.lib.common.exceptions import MSLError
@@ -153,19 +152,18 @@ class MSLRequests(MSLRequestBuilder):
         return {'use_switch_profile': use_switch_profile, 'user_id_token': user_id_token}
 
     @measure_exec_time_decorator(is_immediate=True)
-    def chunked_request(self, endpoint, request_data, esn, disable_msl_switch=True, force_auth_credential=False,
-                        retry_all_exceptions=False):
+    def chunked_request(self, endpoint, request_data, esn, disable_msl_switch=True, force_auth_credential=False):
         """Do a POST request and process the chunked response"""
         self._mastertoken_checks()
         auth_data = self._check_user_id_token(disable_msl_switch, force_auth_credential)
         LOG.debug('Chunked request will be executed with auth data: {}', auth_data)
 
         chunked_response = self._process_chunked_response(
-            self._post(endpoint, self.msl_request(request_data, esn, auth_data), retry_all_exceptions),
+            self._post(endpoint, self.msl_request(request_data, esn, auth_data)),
             save_uid_token_to_owner=auth_data['user_id_token'] is None)
         return chunked_response['result']
 
-    def _post(self, endpoint, request_data, retry_all_exceptions=False):
+    def _post(self, endpoint, request_data):
         """Execute a post request"""
         is_attemps_enabled = 'reqAttempt=' in endpoint
         max_attempts = 3 if is_attemps_enabled else 1
@@ -198,8 +196,6 @@ class MSLRequests(MSLRequestBuilder):
                 return response
             except Exception as exc:  # pylint: disable=broad-except
                 LOG.error('HTTP request error: {}', exc)
-                if not retry_all_exceptions and not isinstance(exc, exceptions.ReadTimeout):
-                    raise
                 if retry_attempt >= max_attempts:
                     raise
                 retry_attempt += 1


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
The Requests module has persistent connections enabled by default, that send "connection: keep-alive" in the headers, Netflix does not use persistent connections and this prevents connection from being returned to the pool that can causing failures with new requests, as seen on Issue #914 and #1004

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
