### PR TITLE
Attempt to better handle HTTP ReadTimeout/ConnectionError errors

### DIFF
--- a/resources/lib/common/exceptions.py
+++ b/resources/lib/common/exceptions.py
@@ -20,10 +20,6 @@ class HttpError401(Exception):
     """The request has returned http error 401 unauthorized for url ..."""
 
 
-class HttpErrorTimeout(Exception):
-    """The request has raised timeout"""
-
-
 class WebsiteParsingError(Exception):
     """Parsing info from the Netflix Website failed"""
 

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -122,6 +122,7 @@ def _play(videoid, is_played_from_strm=False):
 
     # Start and initialize the action controller (see action_controller.py)
     LOG.debug('Sending initialization signal')
+    # Do not use send_signal as threaded slow devices are not powerful to send in faster way and arrive late to service
     common.send_signal(common.Signals.PLAYBACK_INITIATED, {
         'videoid': videoid.to_dict(),
         'videoid_next_episode': videoid_next_episode.to_dict() if videoid_next_episode else None,
@@ -129,7 +130,7 @@ def _play(videoid, is_played_from_strm=False):
         'info_data': info_data,
         'is_played_from_strm': is_played_from_strm,
         'resume_position': resume_position,
-        'event_data': event_data}, non_blocking=True)
+        'event_data': event_data})
     xbmcplugin.setResolvedUrl(handle=G.PLUGIN_HANDLE, succeeded=True, listitem=list_item)
 
 

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -12,7 +12,7 @@ from xbmc import getCondVisibility, Monitor, getInfoLabel
 
 from resources.lib.common.exceptions import (HttpError401, InputStreamHelperError, MbrStatusNeverMemberError,
                                              MbrStatusFormerMemberError, MissingCredentialsError, LoginError,
-                                             NotLoggedInError, InvalidPathError, BackendNotReady, HttpErrorTimeout)
+                                             NotLoggedInError, InvalidPathError, BackendNotReady)
 from resources.lib.common import check_credentials, get_local_string, WndHomeProps
 from resources.lib.globals import G
 from resources.lib.upgrade_controller import check_addon_upgrade
@@ -37,12 +37,11 @@ def catch_exceptions_decorator(func):
                            ('The operation has been cancelled.[CR]'
                             'InputStream Helper has generated an internal error:[CR]{}[CR][CR]'
                             'Please report it to InputStream Helper github.'.format(exc)))
-        except (HttpError401, HttpErrorTimeout) as exc:
-            # HttpError401: This is a generic error, can happen when the http request for some reason has failed.
+        except HttpError401 as exc:
+            # This is a generic error, can happen when the http request for some reason has failed.
             # Known causes:
             # - Possible change of data format or wrong data in the http request (also in headers/params)
             # - Some current nf session data are not more valid (authURL/cookies/...)
-            # HttpErrorTimeout: This error is raised by Requests ReadTimeout error, unknown causes
             from resources.lib.kodi.ui import show_ok_dialog
             show_ok_dialog(get_local_string(30105),
                            ('There was a communication problem with Netflix.[CR]'

--- a/resources/lib/services/msl/events_handler.py
+++ b/resources/lib/services/msl/events_handler.py
@@ -105,7 +105,7 @@ class EventsHandler(threading.Thread):
                                                                'events/{}'.format(event))
         try:
             response = self.chunked_request(endpoint_url, event.request_data, get_esn(),
-                                            disable_msl_switch=False, retry_all_exceptions=True)
+                                            disable_msl_switch=False)
             # Malformed/wrong content in requests are ignored without returning error feedback in the response
             event.set_response(response)
         except Exception as exc:  # pylint: disable=broad-except

--- a/resources/lib/services/msl/msl_requests.py
+++ b/resources/lib/services/msl/msl_requests.py
@@ -10,11 +10,8 @@
 """
 import base64
 import json
-import re
 import time
 import zlib
-
-from requests import exceptions
 
 import resources.lib.common as common
 from resources.lib.common.exceptions import MSLError
@@ -152,19 +149,18 @@ class MSLRequests(MSLRequestBuilder):
         return {'use_switch_profile': use_switch_profile, 'user_id_token': user_id_token}
 
     @measure_exec_time_decorator(is_immediate=True)
-    def chunked_request(self, endpoint, request_data, esn, disable_msl_switch=True, force_auth_credential=False,
-                        retry_all_exceptions=False):
+    def chunked_request(self, endpoint, request_data, esn, disable_msl_switch=True, force_auth_credential=False):
         """Do a POST request and process the chunked response"""
         self._mastertoken_checks()
         auth_data = self._check_user_id_token(disable_msl_switch, force_auth_credential)
         LOG.debug('Chunked request will be executed with auth data: {}', auth_data)
 
         chunked_response = self._process_chunked_response(
-            self._post(endpoint, self.msl_request(request_data, esn, auth_data), retry_all_exceptions),
+            self._post(endpoint, self.msl_request(request_data, esn, auth_data)),
             save_uid_token_to_owner=auth_data['user_id_token'] is None)
         return chunked_response['result']
 
-    def _post(self, endpoint, request_data, retry_all_exceptions=False):
+    def _post(self, endpoint, request_data):
         """Execute a post request"""
         is_attemps_enabled = 'reqAttempt=' in endpoint
         max_attempts = 3 if is_attemps_enabled else 1
@@ -184,8 +180,6 @@ class MSLRequests(MSLRequestBuilder):
                 return response.text
             except Exception as exc:  # pylint: disable=broad-except
                 LOG.error('HTTP request error: {}', exc)
-                if not retry_all_exceptions and not isinstance(exc, exceptions.ReadTimeout):
-                    raise
                 if retry_attempt >= max_attempts:
                     raise
                 retry_attempt += 1

--- a/resources/lib/services/nfsession/session/http_requests.py
+++ b/resources/lib/services/nfsession/session/http_requests.py
@@ -14,7 +14,7 @@ import time
 import resources.lib.common as common
 import resources.lib.utils.website as website
 from resources.lib.common.exceptions import (APIError, WebsiteParsingError, MbrStatusError, MbrStatusAnonymousError,
-                                             HttpError401, NotLoggedInError, HttpErrorTimeout)
+                                             HttpError401, NotLoggedInError)
 from resources.lib.database.db_utils import TABLE_SESSION
 from resources.lib.globals import G
 from resources.lib.kodi import ui
@@ -46,7 +46,6 @@ class SessionHTTPRequests(SessionBase):
         return self._request(method, endpoint, None, **kwargs)
 
     def _request(self, method, endpoint, session_refreshed, **kwargs):
-        from requests import exceptions
         endpoint_conf = ENDPOINTS[endpoint]
         url = (_api_url(endpoint_conf['address'])
                if endpoint_conf['is_api_call']
@@ -55,17 +54,13 @@ class SessionHTTPRequests(SessionBase):
                   verb='GET' if method == self.session.get else 'POST', url=url)
         data, headers, params = self._prepare_request_properties(endpoint_conf, kwargs)
         start = time.perf_counter()
-        try:
-            response = method(
-                url=url,
-                verify=self.verify_ssl,
-                headers=headers,
-                params=params,
-                data=data,
-                timeout=8)
-        except exceptions.ReadTimeout as exc:
-            LOG.error('HTTP Request ReadTimeout error: {}', exc)
-            raise HttpErrorTimeout from exc
+        response = method(
+            url=url,
+            verify=self.verify_ssl,
+            headers=headers,
+            params=params,
+            data=data,
+            timeout=8)
         LOG.debug('Request took {}s', time.perf_counter() - start)
         LOG.debug('Request returned status code {}', response.status_code)
         # for redirect in response.history:

--- a/resources/lib/services/nfsession/session/http_requests.py
+++ b/resources/lib/services/nfsession/session/http_requests.py
@@ -11,6 +11,8 @@
 import json
 import time
 
+import requests.exceptions as req_exceptions
+
 import resources.lib.common as common
 import resources.lib.utils.website as website
 from resources.lib.common.exceptions import (APIError, WebsiteParsingError, MbrStatusError, MbrStatusAnonymousError,
@@ -50,19 +52,30 @@ class SessionHTTPRequests(SessionBase):
         url = (_api_url(endpoint_conf['address'])
                if endpoint_conf['is_api_call']
                else _document_url(endpoint_conf['address'], kwargs))
-        LOG.debug('Executing {verb} request to {url}',
-                  verb='GET' if method == self.session.get else 'POST', url=url)
         data, headers, params = self._prepare_request_properties(endpoint_conf, kwargs)
-        start = time.perf_counter()
-        response = method(
-            url=url,
-            verify=self.verify_ssl,
-            headers=headers,
-            params=params,
-            data=data,
-            timeout=8)
-        LOG.debug('Request took {}s', time.perf_counter() - start)
-        LOG.debug('Request returned status code {}', response.status_code)
+        retry = 1
+        while True:
+            try:
+                LOG.debug('Executing {verb} request to {url}',
+                          verb='GET' if method == self.session.get else 'POST', url=url)
+                start = time.perf_counter()
+                response = method(
+                    url=url,
+                    verify=self.verify_ssl,
+                    headers=headers,
+                    params=params,
+                    data=data,
+                    timeout=8)
+                LOG.debug('Request took {}s', time.perf_counter() - start)
+                LOG.debug('Request returned status code {}', response.status_code)
+                break
+            except (req_exceptions.ConnectionError, req_exceptions.ReadTimeout) as exc:
+                # Info on PR: https://github.com/CastagnaIT/plugin.video.netflix/pull/1046
+                LOG.error('HTTP request error: {}', exc)
+                if retry == 3:
+                    raise
+                retry += 1
+                LOG.warn('Another attempt will be performed ({})', retry)
         # for redirect in response.history:
         #     LOG.warn('Redirected to: [{}] {}', redirect.status_code, redirect.url)
         if not session_refreshed:
@@ -84,7 +97,6 @@ class SessionHTTPRequests(SessionBase):
 
     def try_refresh_session_data(self, raise_exception=False):
         """Refresh session data from the Netflix website"""
-        from requests import exceptions
         try:
             self.auth_url = website.extract_session_data(self.get('browse'))['auth_url']
             cookies.save(self.session.cookies)
@@ -105,7 +117,7 @@ class SessionHTTPRequests(SessionBase):
             common.purge_credentials()
             ui.show_notification(common.get_local_string(30008))
             raise NotLoggedInError from exc
-        except exceptions.RequestException:
+        except req_exceptions.RequestException:
             import traceback
             LOG.warn('Failed to refresh session data, request error (RequestException)')
             LOG.warn(traceback.format_exc())


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Some users have encountered HTTP errors as:
`ConnectionError: ('Connection aborted.', error("(104, 'ECONNRESET')",))`
Issue #1004
`ReadTimeout: HTTPSConnectionPool(host='www.n*****x.com', port=443): Read timed out. (read timeout=None)`
Issue #914

I have no idea if the cause is the network or the Netflix servers, or a bug in Requests/Urlib module
this problem happen only with some users on linux/windows platform and on both Kodi 18/19 (python 2 and 3)

For the "Connection aborted ... ECONNRESET" error case, has been tried every type of solutions provided from:
https://github.com/psf/requests/issues/4937
https://github.com/psf/requests/issues/3845

Solutions tried:
- Tried to add extra time between HTTP requests (time.sleep(0,5))
- Tried to use a single Requests session object (on NF session service) instead of two (one on MSL service / one on NF session service)
- Tried to install (on python 2):
```
pip install requests[security]
pip install pyopenssl ndg-httpsclient pyasn1
```
- Tried to add custom HTTPAdapters with max_retries
```
from requests.adapters import HTTPAdapter
session.mount('http', HTTPAdapter(max_retries=3))
session.mount('https', HTTPAdapter(max_retries=3))
```

Nothing works

I don't remember in which Issue message, but i read about a possible Request or Urlib bug that in some situations doesn't close opened persistent connections anymore, therefore on next http request cause the ConnectionError ... ECONNRESET.

Perhaps something similar is true, because if you force to close the connection by add on each HTTP request the header
`Connection: close` the ConnectionError ... ECONNRESET _error not happen anymore_,
although i don't understand why it only happens to certain users

but forcing close the connetion on each request does not seem to me to be good practice to do with HTTP1.1 servers.
so as workaround i added a simple retry loop.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
