### PR TITLE
Add clear "stream continuity" data

### DIFF
--- a/resources/lib/database/db_shared.py
+++ b/resources/lib/database/db_shared.py
@@ -462,6 +462,13 @@ def get_shareddb_class(use_mysql=False):
 
         @db_base_mysql.handle_connection
         @db_base_sqlite.handle_connection
+        def clear_stream_continuity(self):
+            """Clear all stream continuity data"""
+            query = 'DELETE FROM stream_continuity'
+            self._execute_non_query(query)
+
+        @db_base_mysql.handle_connection
+        @db_base_sqlite.handle_connection
         def purge_library(self):
             """Delete all records from library tables"""
             query = 'DELETE FROM video_lib_movies'

--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -137,7 +137,10 @@ class AddonActionExecutor:
     @measure_exec_time_decorator()
     def purge_cache(self, pathitems=None):  # pylint: disable=unused-argument
         """Clear the cache. If on_disk param is supplied, also clear cached items from disk"""
-        G.CACHE.clear(clear_database=self.params.get('on_disk', False))
+        _on_disk = self.params.get('on_disk', False)
+        G.CACHE.clear(clear_database=_on_disk)
+        if _on_disk:
+            G.SHARED_DB.clear_stream_continuity()
         ui.show_notification(common.get_local_string(30135))
 
     def force_update_list(self, pathitems=None):  # pylint: disable=unused-argument

--- a/resources/lib/upgrade_controller.py
+++ b/resources/lib/upgrade_controller.py
@@ -70,6 +70,12 @@ def _perform_service_changes(previous_ver, current_ver):
     LOG.debug('Initialize service upgrade operations, from version {} to {})', previous_ver, current_ver)
     # Clear cache (prevents problems when netflix change data structures)
     G.CACHE.clear()
+    # Delete all stream continuity data - if user has upgraded from Kodi 18 to Kodi 19
+    if is_less_version(previous_ver, '1.13'):
+        # There is no way to determine if the user has migrated from Kodi 18 to Kodi 19,
+        #   then we assume that add-on versions prior to 1.13 was on Kodi 18
+        # The am_stream_continuity.py on Kodi 18 works differently and the existing data can not be used on Kodi 19
+        G.SHARED_DB.clear_stream_continuity()
     if previous_ver and is_less_version(previous_ver, '1.9.0'):
         # In the version 1.9.0 has been changed the COOKIE_ filename with a static filename
         from resources.lib.upgrade_actions import rename_cookie_file


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
When migrating from Kodi 18 add-on version to Kodi 19 add-on version the existing "stream continuity" data is no more compatible, then is needed to delete all existing data
In addition this add the possibility to delete the data also when the user perform clear cache (on disk) on expert settings

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
