### PR TITLE
Implemented Pickle serialization on xbmcgui.ListItem

### DIFF
--- a/resources/lib/common/kodi_wrappers.py
+++ b/resources/lib/common/kodi_wrappers.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2017 Sebastian Golasch (plugin.video.netflix)
+    Copyright (C) 2021 Stefano Gottardo - @CastagnaIT (original implementation module)
+    Wrappers of Kodi methods and objects
+
+    SPDX-License-Identifier: MIT
+    See LICENSES/MIT.md for more information.
+"""
+from typing import Dict, List, Tuple
+
+import xbmcgui
+
+
+# pylint: disable=redefined-builtin,invalid-name
+class ListItemW(xbmcgui.ListItem):
+    """
+    Wrapper for xbmcgui.ListItem
+    to make it serializable with Pickle and provide helper functions ('offscreen' will be True by default)
+    """
+
+    def __init__(self, label='', label2='', path=''):
+        super().__init__(label, label2, path, True)
+        self.__dict__.update({
+            'properties': {},
+            'infolabels': {},
+            'art': {},
+            'stream_info': {}
+        })
+
+    def __getnewargs__(self):  # Pickle method
+        """Passes arguments to __new__ method"""
+        return self.getLabel(), self.getLabel2(), self.getPath(), True
+
+    def __setstate__(self, state):  # Pickle method
+        """Restore the state of the object data"""
+        self.setContentLookup(False)
+        super().setInfo('video', state['infolabels'])
+        super().setProperties(state['properties'])
+        super().setArt(state['art'])
+        for stream_type, quality_info in state['stream_info'].items():
+            super().addStreamInfo(stream_type, quality_info)
+        super().addContextMenuItems(state.get('context_menus', []))
+        super().select(state.get('is_selected', False))
+
+    # In the 'xbmcgui.ListItem' is missing a lot of get/set methods then pickle cannot be implemented on C++ side,
+    #   so we override these methods to store locally the values that will be re-assigned when the object
+    #   will be unpickled with __setstate__, if is needed reuse these methods remove the comments from the code,
+    #   the data assignment to the original ListItem object is initially avoided to improve performance
+
+    def setInfo(self, type: str, infoLabels: Dict[str, str]):
+        # NOTE: 'type' argument is ignored because we use only 'video' type, but kept for future changes
+        # super().setInfo(type, infoLabels)
+        self.__dict__['infolabels'] = infoLabels
+
+    def setProperty(self, key: str, value: str):
+        super().setProperty(key, value)
+        self.__dict__['properties'][key] = value
+
+    def setProperties(self, dictionary: Dict[str, str]):
+        super().setProperties(dictionary)
+        self.__dict__['properties'].update(dictionary)
+
+    def setArt(self, dictionary: Dict[str, str]):
+        # super().setArt(dictionary)
+        self.__dict__['art'].update(dictionary)
+
+    def addStreamInfo(self, cType: str, dictionary: Dict[str, str]):
+        # super().addStreamInfo(cType, dictionary)
+        self.__dict__['stream_info'][cType] = dictionary
+
+    def addContextMenuItems(self, items: List[Tuple[str, str]], replaceItems = False):
+        # NOTE: 'replaceItems' argument is ignored because not works
+        # super().addContextMenuItems(items)
+        self.__dict__['context_menus'] = items
+
+    def select(self, selected: bool):
+        # super().select(selected)
+        self.__dict__['is_selected'] = selected
+
+    # Custom helper methods
+
+    def addStreamInfoFromDict(self, dictionary):
+        """Add or update all stream info from a dictionary"""
+        self.__dict__['stream_info'].update(dictionary)
+
+    def updateInfo(self, dictionary):
+        """Add or update data over the existing data previously added with 'setInfo'"""
+        self.__dict__['infolabels'].update(dictionary)

--- a/resources/lib/kodi/ui/xmldialog_profiles.py
+++ b/resources/lib/kodi/ui/xmldialog_profiles.py
@@ -22,7 +22,7 @@ class Profiles(xbmcgui.WindowXMLDialog):
         self.ctrl_list = None
         self.return_value = None
         self.title = kwargs['title']
-        self.list_data = kwargs['list_data']
+        self.dir_items = kwargs['dir_items']
         self.preselect_guid = kwargs.get('preselect_guid')
         self.action_exit_keys_id = [ACTION_PREVIOUS_MENU,
                                     ACTION_PLAYER_STOP,
@@ -30,15 +30,16 @@ class Profiles(xbmcgui.WindowXMLDialog):
         super().__init__(*args)
 
     def onInit(self):
+        # Keep only the ListItem objects
+        list_items = [list_item for (_, list_item, _) in self.dir_items]
         self.getControl(99).setLabel(self.title)
         self.ctrl_list = self.getControl(10001)
-        from resources.lib.navigation.directory_utils import convert_list_to_list_items
-        self.ctrl_list.addItems(convert_list_to_list_items(self.list_data))
+        self.ctrl_list.addItems(list_items)
         # Preselect the ListItem by guid
         self.ctrl_list.selectItem(0)
         if self.preselect_guid:
-            for index, profile_data in enumerate(self.list_data):
-                if profile_data['properties']['nf_guid'] == self.preselect_guid:
+            for index, list_item in enumerate(list_items):
+                if list_item.getProperty('nf_guid') == self.preselect_guid:
                     self.ctrl_list.selectItem(index)
                     break
         self.setFocusId(10001)

--- a/resources/lib/kodi/ui/xmldialogs.py
+++ b/resources/lib/kodi/ui/xmldialogs.py
@@ -123,7 +123,7 @@ def show_profiles_dialog(title=None, title_prefix=None, preselect_guid=None):
         title = title_prefix + ' - ' + title
     # Get profiles data
     # pylint: disable=unused-variable
-    list_data, extra_data = make_call('get_profiles',
+    dir_items, extra_data = make_call('get_profiles',
                                       {'request_update': True,
                                        'preselect_guid': preselect_guid,
                                        'detailed_info': False})
@@ -132,7 +132,7 @@ def show_profiles_dialog(title=None, title_prefix=None, preselect_guid=None):
                              Profiles,
                              'plugin-video-netflix-Profiles.xml',
                              title=title,
-                             list_data=list_data,
+                             dir_items=dir_items,
                              preselect_guid=preselect_guid)
 
 

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -136,7 +136,6 @@ def get_inputstream_listitem(videoid):
     list_item = xbmcgui.ListItem(path=service_url + manifest_path, offscreen=True)
     list_item.setContentLookup(False)
     list_item.setMimeType('application/xml+dash')
-    list_item.setProperty('isFolder', 'false')
     list_item.setProperty('IsPlayable', 'true')
     try:
         import inputstreamhelper

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_utils.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_utils.py
@@ -10,6 +10,7 @@
 import os
 
 import resources.lib.common as common
+from resources.lib.common.kodi_wrappers import ListItemW
 from resources.lib.globals import G
 
 
@@ -22,24 +23,20 @@ def add_items_previous_next_page(directory_items, pathitems, perpetual_range_sel
         if 'previous_start' in perpetual_range_selector:
             params = {'perpetual_range_start': perpetual_range_selector.get('previous_start'),
                       'sub_genre_id': sub_genre_id if perpetual_range_selector.get('previous_start') == 0 else None}
-            previous_page_item = {
-                'url': common.build_url(pathitems=pathitems, params=params, mode=G.MODE_DIRECTORY),
-                'label': common.get_local_string(30148),
-                'art': {'thumb': _get_custom_thumb_path('FolderPagePrevious.png')},
-                'is_folder': True,
-                'properties': {'specialsort': 'top'}  # Force an item to stay on top (not documented in Kodi)
-            }
-            directory_items.insert(0, previous_page_item)
+            previous_page_item = ListItemW(label=common.get_local_string(30148))
+            previous_page_item.setProperty('specialsort', 'top')  # Force an item to stay on top
+            previous_page_item.setArt({'thumb': _get_custom_thumb_path('FolderPagePrevious.png')})
+            directory_items.insert(0, (common.build_url(pathitems=pathitems, params=params, mode=G.MODE_DIRECTORY),
+                                       previous_page_item,
+                                       True))
         if 'next_start' in perpetual_range_selector:
             params = {'perpetual_range_start': perpetual_range_selector.get('next_start')}
-            next_page_item = {
-                'url': common.build_url(pathitems=pathitems, params=params, mode=G.MODE_DIRECTORY),
-                'label': common.get_local_string(30147),
-                'art': {'thumb': _get_custom_thumb_path('FolderPageNext.png')},
-                'is_folder': True,
-                'properties': {'specialsort': 'bottom'}  # Force an item to stay on bottom (not documented in Kodi)
-            }
-            directory_items.append(next_page_item)
+            next_page_item = ListItemW(label=common.get_local_string(30147))
+            next_page_item.setProperty('specialsort', 'bottom')  # Force an item to stay on bottom
+            next_page_item.setArt({'thumb': _get_custom_thumb_path('FolderPageNext.png')})
+            directory_items.append((common.build_url(pathitems=pathitems, params=params, mode=G.MODE_DIRECTORY),
+                                    next_page_item,
+                                    True))
 
 
 def get_param_watched_status_by_profile():


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Due to the lack of serialization in Kodi python objects, it has never been possible to efficiently simplify the general management of the source code, mainly because we do all the data management within the service python instance, and so they must be transferred to the "frontend" python instance through IPC.

ATM Pickle serialization cannot implemented directly on Kodi side, because mainly is missing a lot of getter/setter methods, and in general the ListItem class is quite badly made...

After several attempts to try use Pickle with the `xbmcgui.ListItem` object i was able to create a wrapper to allow the Pickle serialization by temporary storing the values needed for Pickle serialization,
and now and thanks to the recently changes on IPC side, we can take the advantage of Pickle's serialization to simplify and clean the source code.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
