### PR TITLE
New video manifest request

### DIFF
--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -36,6 +36,8 @@ INPUTSTREAM_SERVER_CERTIFICATE = (
     'ovtl/ogZgjMeEdFyd/9YMYjOS4krYmwp3yJ7m9ZzYCQ6I8RQN4x/yLlHG5RH/+WNLNUs6JAZ'
     '0fFdCmw=')
 
+PSSH_KID = 'AAAANHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABQIARIQAAAAAAPSZ0kAAAAAAAAAAA==|AAAAAAPSZ0kAAAAAAAAAAA=='
+
 
 @common.inject_video_id(path_offset=0, pathitems_arg='videoid', inject_full_pathitems=True)
 def play_strm(videoid):
@@ -125,6 +127,10 @@ def get_inputstream_listitem(videoid):
     list_item.setProperty(
         key='inputstream',
         value='inputstream.adaptive')
+    # Set PSSH/KID to pre-initialize the DRM to get challenge/session ID data in the ISA manifest proxy callback
+    list_item.setProperty(
+        key='inputstream.adaptive.pre_init_data',
+        value=PSSH_KID)
     return list_item
 
 

--- a/resources/lib/services/http_server.py
+++ b/resources/lib/services/http_server.py
@@ -10,7 +10,7 @@
 import pickle
 from http.server import BaseHTTPRequestHandler
 from socketserver import TCPServer, ThreadingMixIn
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, unquote
 
 from resources.lib.common import IPC_ENDPOINT_CACHE, IPC_ENDPOINT_NFSESSION, IPC_ENDPOINT_MSL, IPC_ENDPOINT_NFSESSION_TEST
 from resources.lib.common.exceptions import InvalidPathError, CacheMiss, MetadataNotAvailable, SlotNotImplemented
@@ -78,7 +78,11 @@ def handle_msl_request(server, func_name, data, params=None):
     elif func_name == 'get_manifest':
         # Proxy for InputStream Adaptive to get the XML manifest for the requested video
         videoid = int(params['videoid'][0])
-        manifest_data = server.server.netflix_session.msl_handler.get_manifest(videoid)
+        challenge = server.headers['challengeB64']
+        sid = server.headers['sessionId']
+        if not challenge or not sid:
+            raise Exception(f'Widevine session data not valid\r\nSession ID: {sid} Challenge: {challenge}')
+        manifest_data = server.server.netflix_session.msl_handler.get_manifest(videoid, unquote(challenge), sid)
         server.send_response(200)
         server.send_header('Content-type', 'application/xml')
         server.end_headers()

--- a/resources/lib/services/nfsession/msl/msl_handler.py
+++ b/resources/lib/services/nfsession/msl/msl_handler.py
@@ -38,34 +38,6 @@ class MSLHandler:
     licenses_session_id = []
     licenses_xid = []
     licenses_release_url = []
-    manifest_challenge = ('CAESwQsKhgsIARLsCQqvAggCEhGN3Th6q2GhvXw9bD+X9aW2ChjQ8PLmBSKOAjCCAQoCggEBANsVUL5yI9K'
-                          'UG1TPpb1A0bzk6df3YwbpDEkh+IOj52RfnKyspASRN1JQvCRrKwiq433M9BV+8ZkzkheYEPZ9X5rl5Ydkwp'
-                          'qedzdZRAiuaVp/mMA5zUM3I3fZogVxGnVzh4mB2URg+g7TFwbPWz2x1uzPumO+2ImOPIUyR7auoOKrZml30'
-                          '8w8Edwdd1HwFyrJEZHLDN2P51PJhVrUBWUlxebY05NhfIUvWQ/pyXAa6AahTf7PTVow/uu1d0vc6gHSxmj0'
-                          'hodvaxrkDcBY9NoOH2XCW7LNJnKC487CVwCHOJC9+6fakaHnjHepayeGEp2JL2AaCrGGqAOZdG8F11Pa0H8'
-                          'CAwEAASirbxKAAmFqOFvUp7caxO5/q2QK5yQ8/AA5E1KOQJxZrqwREPbGUX3670XGw9bamA0bxc37DUi6Dw'
-                          'rOyWKWSaW/qVNie86mW/7KdVSpZPGcF/TxO+kd4iXMIjH0REZst/mMJhv5UMMO9dDFGR3RBqkPbDTdzvX1u'
-                          'E/loVPDH8QEfDACzDkeCA1P0zAcjWKGPzaeUrogsnBEQN4wCVRQqufDXkgImhDUCUkmyQDJXQkhgMMWtbbC'
-                          'HMa/DMGEZAhu4I8G32m8XxU3NoK1kDsb+s5VUgOdkX3ZnFw1uf3niQ9FCTYlzv4SIBJGEokJjkHagT6kVWf'
-                          'hsvSHMHzayKb00OwIn/6NsNEatAUKrgIIARIQiX9ghrmqxsdcq/w8cprG8Bj46/LmBSKOAjCCAQoCggEBAL'
-                          'udF8e+FexCGnOsPQCNtaIvTRW8XsqiTxdo5vElAnGMoOZn6Roy2jwDkc1Gy2ucybY926xk0ZP2Xt5Uy/atI'
-                          '5yAvn7WZGWzbR5BbMbXIxaCyDysm7L+X6Fid55YbJ8GLl2/ToOY2CVYT+EciaTj56OjcyBJLDW/0Zqp25gn'
-                          'da61HwomZOVLoFmLbeZtC5DjvEv8c2NIDXXketqd/vj0I1nWKtEy8nKIPw/2nhitR6QFUnfEb8hJgPgdTAp'
-                          'TkxWm4hSpWsM0j8CQOYNzDL2/kfP1cYw0Fh7oJMSEt2H6AUjC4lIkp54rPHAhLYE+tmwKSYfrmjEoTVErcI'
-                          'jl6jEvwtsCAwEAASirbxKAA0OHZIfwXbTghTVi4awHyXje/8D5fdtggtTa0Edec0KmZbHwBbLJ9OCBc9RrR'
-                          'L8O4WgQPG/5RVLc9IsR9x/Gw1vg/X+MmWEBnY62XNdVAUjbYGwRQuHQFMkwEQdzxfcH9oWoJtOZdLEN2X/p'
-                          'Ws7MeM4KZc8gTUqcDHekq1QqKNs+Voc8Q5hIX7fims9llY/RUHNatDPFVuEyJ0Vqx5l+Rrrdqk+b1fXuVR6'
-                          'yxP1h4S/C/UtedUyZxZgc/1OJ0mLr5x1tkRbFVyzA8Z/qfZeYq3HV4pAGg7nLg0JRBTbjiZH8eUhr1JtwLi'
-                          'udU9vLvDnv1Y6bsfaT62vfLOttozSZVIeWo7acZHICduOL/tH1Kx7f6e7ierwQYAOng1LGs/PLofQ874C1A'
-                          'tNkN0tVe6cSSAvN+Vl33GbICXpX6Rq8LBPqqhzGMGBMiybnmXqOaXz8ngSQCiXqp/ImaOKfx8OE6qH92rUV'
-                          'Wgw68qBy9ExEOl95SSEx9A/B4vEYFHaHwzqh2BoYChFhcmNoaXRlY3R1cmVfbmFtZRIDYXJtGhYKDGNvbXB'
-                          'hbnlfbmFtZRIGR29vZ2xlGhcKCm1vZGVsX25hbWUSCUNocm9tZUNETRoZCg1wbGF0Zm9ybV9uYW1lEghDaH'
-                          'JvbWVPUxojChR3aWRldmluZV9jZG1fdmVyc2lvbhILNC4xMC4xNjEwLjYyCAgBEAAYACABEiwKKgoUCAESE'
-                          'AAAAAAD0mdJAAAAAAAAAAAQARoQA5cwqbEo4TSV6p1qQZy26BgBIOSrw/cFMBUagAIp7zGUC9p3XZ9sp0w+'
-                          'yd6/wyRa1V22NyPF4BsNivSEkMtcEaQiUOW+LrGhHO+RrukWeJlzVbtpai5/vjOAbsaouQ0yMp8yfpquZcV'
-                          'kpPugSOPKu1A0W5w5Ou9NOGsMaJi6+LicGxhS+7xAp/lv/9LATCcQJXS2elBCz6f6VUQyMOPyjQYBrH3h27'
-                          'tVRcsnTRQATcogwCytXohKroBGvODIYcpVFsy2saOCyh4HTezzXJvgogx2f15ViyF5rDqho4YsW0z4it9TF'
-                          'BT0OOLkk0fQ6a1LSqA49eN3RufKYq4LT+G+ffdgoDmKpIWS3bp7xQ6GeYtDAUh0D8Ipwc8aKzP2')
 
     def __init__(self, nfsession: 'NFSessionOperations'):
         self.nfsession = nfsession
@@ -116,7 +88,7 @@ class MSLHandler:
             self.events_handler_thread.start()
 
     @display_error_info
-    def get_manifest(self, viewable_id):
+    def get_manifest(self, viewable_id, challenge, sid):
         """
         Get the manifests for the given viewable_id and returns a mpd-XML-Manifest
 
@@ -128,7 +100,7 @@ class MSLHandler:
             # When the add-on is installed from scratch or you logout the account the ESN will be empty
             if not esn:
                 esn = set_esn()
-            manifest = self._get_manifest(viewable_id, esn)
+            manifest = self._get_manifest(viewable_id, esn, challenge, sid)
         except MSLError as exc:
             if 'Email or password is incorrect' in str(exc):
                 # Known cases when MSL error "Email or password is incorrect." can happen:
@@ -141,7 +113,7 @@ class MSLHandler:
         return self.__tranform_to_dash(manifest)
 
     @measure_exec_time_decorator(is_immediate=True)
-    def _get_manifest(self, viewable_id, esn):
+    def _get_manifest(self, viewable_id, esn, challenge, sid):
         cache_identifier = f'{esn}_{viewable_id}'
         try:
             # The manifest must be requested once and maintained for its entire duration
@@ -170,7 +142,7 @@ class MSLHandler:
         if hdcp_4k_capable and hdcp_override:
             hdcp_version = ['2.2']
 
-        LOG.info('Requesting manifest for {} with ESN {} and HDCP {}',
+        LOG.info('Requesting licensed manifest for {} with ESN {} and HDCP {}',
                  viewable_id,
                  common.censure(esn) if len(esn) > 50 else esn,
                  hdcp_version)
@@ -211,24 +183,25 @@ class MSLHandler:
                 'supportedHdcpVersions': hdcp_version,
                 'isHdcpEngaged': hdcp_override
             }],
-            'preferAssistiveAudio': False
+            'preferAssistiveAudio': False,
+            'profileGroups': [{
+                'name': 'default',
+                'profiles': profiles
+            }],
+            'licenseType': 'standard',
+            'challenge': challenge,
+            'challenges': {
+                'default': [{
+                    'drmSessionId': sid,
+                    'clientTime': int(time.time()),
+                    'challengeBase64': challenge
+                }]
+            }
         }
 
-        if 'linux' in common.get_system_platform():
-            machine_arch = common.get_machine()
-            if machine_arch.startswith('arm') or machine_arch.startswith('aarch'):
-                # 24/06/2020 To get until to 1080P resolutions under arm devices (ChromeOS), android excluded,
-                #   is mandatory to add the widevine challenge data (key request) to the manifest request.
-                # Is not possible get the key request from the default_crypto, is needed to implement
-                #   the wv crypto (used for android) but currently InputStreamAdaptive support this interface only
-                #   under android OS.
-                # As workaround: Initially we pass an hardcoded challenge data needed to play the first video,
-                #   then when ISA perform the license callback we replace it with the fresh license challenge data.
-                params['challenge'] = self.manifest_challenge
-
-        endpoint_url = ENDPOINTS['manifest'] + create_req_params(0, 'prefetch/manifest')
+        endpoint_url = ENDPOINTS['manifest'] + create_req_params(0, 'licensedManifest')
         manifest = self.msl_requests.chunked_request(endpoint_url,
-                                                     self.msl_requests.build_request_data('/manifest', params),
+                                                     self.msl_requests.build_request_data('licensedManifest', params),
                                                      esn,
                                                      disable_msl_switch=False)
         if LOG.is_enabled:
@@ -259,7 +232,6 @@ class MSLHandler:
             'challengeBase64': challenge,
             'xid': xid
         }]
-        self.manifest_challenge = challenge
         endpoint_url = ENDPOINTS['license'] + create_req_params(0, 'prefetch/license')
         try:
             response = self.msl_requests.chunked_request(endpoint_url,

--- a/resources/lib/services/nfsession/msl/msl_handler.py
+++ b/resources/lib/services/nfsession/msl/msl_handler.py
@@ -188,16 +188,17 @@ class MSLHandler:
                 'name': 'default',
                 'profiles': profiles
             }],
-            'licenseType': 'standard',
-            'challenge': challenge,
-            'challenges': {
+            'licenseType': 'standard'
+        }
+        if challenge and sid:
+            params['challenge'] = challenge
+            params['challenges'] = {
                 'default': [{
                     'drmSessionId': sid,
                     'clientTime': int(time.time()),
                     'challengeBase64': challenge
                 }]
             }
-        }
 
         endpoint_url = ENDPOINTS['manifest'] + create_req_params(0, 'licensedManifest')
         manifest = self.msl_requests.chunked_request(endpoint_url,

--- a/resources/lib/upgrade_controller.py
+++ b/resources/lib/upgrade_controller.py
@@ -9,7 +9,7 @@
 """
 from resources.lib.common.misc_utils import CmpVersion
 from resources.lib.database.db_update import run_local_db_updates, run_shared_db_updates
-from resources.lib.globals import G
+from resources.lib.globals import G, remove_ver_suffix
 from resources.lib.utils.logging import LOG
 
 
@@ -60,6 +60,14 @@ def _perform_addon_changes(previous_ver, current_ver):
         from resources.lib.upgrade_actions import migrate_library
         migrate_library()
         cancel_playback = True
+    if previous_ver and CmpVersion(previous_ver) < '1.16.2':
+        from xbmcaddon import Addon
+        isa_version = remove_ver_suffix(Addon('inputstream.adaptive').getAddonInfo('version'))
+        if CmpVersion(isa_version) < '2.6.18':
+            from resources.lib.kodi import ui
+            ui.show_ok_dialog('Netflix add-on upgrade',
+                              'The currently installed [B]InputStream Adaptive add-on[/B] version not support Netflix HD videos.'
+                              '[CR]To get HD video contents, please update it to the last version.')
     # Always leave this to last - After the operations set current version
     G.LOCAL_DB.set_value('addon_previous_version', current_ver)
     return cancel_playback


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
There are new changes to the video manifest request, that require DRM info of the current session, the problem is always the same we do not know if the DRM info will be mandatory to add, this could be a big problem for the future of this addon...

---

Required info to add to netflix manifeste request:
- DRM session ID
- DRM key request (challenge)

#### Android case
~These changes can be done in "easy way" for Android system case thanks to Kodi DRM interface
but currently is lack of a method to get the session ID.
[UPDATE] i have tried to add the support to get the session ID to Kodi interface (commit: https://github.com/CastagnaIT/xbmc/commit/2ac2de106375957f306eb27bdf8f5503312af92f) but currently i have not tested need to build kodi android apk.~

~The only question is: the Kodi DRM interface provide a DRM session ID for crypting data, i suspect that it is different from the DRM session opened by ISA for video playback, this could be a problem? need testing (for HD content)~

#### All other systems (Windows/Linux/Mac)

~How to get DRM session info on these platforms?~
~1) Kodi provide a [DRM interface](https://codedocs.xyz/xbmc/xbmc/group__python__xbmcdrm.html#details) but only for Android~
~2) InputStreamAdaptive do not allow to provide any DRM info and seem that the DRM session is constructed only after the manifest callback (if i understand is inside Session::InitializeDRM() method https://github.com/xbmc/inputstream.adaptive/blob/Matrix/src/main.cpp#L2258)~

~I have no idea on how to proceed, it is not easy situation (at least to me...i am not a widevine guru)
we can hope that netflix not cut out the old manifest request way (that we use) in short~

Currently netflix also accepts to not specify the session ID, but we do not know if this option will be removed in the future...

~I don't think i will be able to solve this situation on my own~ require changes to Kodi core and/or InputStreamAdaptive (opened Issue https://github.com/xbmc/inputstream.adaptive/issues/666)
I will try to do some experiments i can't say any more at the moment

## UPDATE 28/06/2021: 
based on the suggestions i was able to make the necessary changes to ISA follow PR: https://github.com/xbmc/inputstream.adaptive/pull/725
Tests on my ARM device are running at 1080P with success
~but is needed tests also on android devices with L3 and L1
i can provide ISA binary to make tests on various platforms next days~
all tests are ok!

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->
Make the video manifest request as done until now could be obsolete in near future

#### Describe the new behavior
<!--- Put your text below this line -->
Make the video manifest request with DRM session info

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
