### PR TITLE
Fixed wrong selection of impaired audio track

### DIFF
--- a/resources/lib/common/kodi_ops.py
+++ b/resources/lib/common/kodi_ops.py
@@ -207,6 +207,16 @@ def get_kodi_ui_language(iso_format=xbmc.ISO_639_1):
     return convert_language_iso(setting.split('.')[-1][:2], iso_format)
 
 
+def get_kodi_is_prefer_sub_impaired():
+    """Return True if subtitles for impaired are enabled in Kodi settings"""
+    return json_rpc('Settings.GetSettingValue', {'setting': 'accessibility.subhearing'})['value']
+
+
+def get_kodi_is_prefer_audio_impaired():
+    """Return True if audio for impaired is enabled in Kodi settings"""
+    return json_rpc('Settings.GetSettingValue', {'setting': 'accessibility.audiovisual'})['value']
+
+
 def convert_language_iso(from_value, iso_format=xbmc.ISO_639_1):
     """
     Convert given value (English name or two/three letter code) to the specified format

--- a/resources/lib/services/playback/am_stream_continuity.py
+++ b/resources/lib/services/playback/am_stream_continuity.py
@@ -59,8 +59,6 @@ class AMStreamContinuity(ActionManager):
         self.resume = {}
         self.is_kodi_forced_subtitles_only = None
         self.is_prefer_alternative_lang = None
-        self.is_prefer_sub_impaired = None
-        self.is_prefer_audio_impaired = None
 
     def __str__(self):
         return ('enabled={}, videoid_parent={}'
@@ -69,10 +67,6 @@ class AMStreamContinuity(ActionManager):
     def initialize(self, data):
         self.is_kodi_forced_subtitles_only = common.get_kodi_subtitle_language() == 'forced_only'
         self.is_prefer_alternative_lang = G.ADDON.getSettingBool('prefer_alternative_lang')
-        self.is_prefer_sub_impaired = common.json_rpc('Settings.GetSettingValue',
-                                                      {'setting': 'accessibility.subhearing'}).get('value')
-        self.is_prefer_audio_impaired = common.json_rpc('Settings.GetSettingValue',
-                                                        {'setting': 'accessibility.audiovisual'}).get('value')
 
     def on_playback_started(self, player_state):
         is_enabled = G.ADDON.getSettingBool('StreamContinuityManager_enabled')
@@ -248,7 +242,7 @@ class AMStreamContinuity(ActionManager):
         lang_code = _find_lang_with_country_code(audio_list, pref_audio_language)
         if lang_code and common.get_kodi_audio_language() not in ['mediadefault', 'original']:
             stream_audio = None
-            if self.is_prefer_audio_impaired:
+            if common.get_kodi_is_prefer_audio_impaired():
                 stream_audio = next((audio_track for audio_track in audio_list
                                      if audio_track['language'] == lang_code
                                      and audio_track['isimpaired']
@@ -350,7 +344,7 @@ class AMStreamContinuity(ActionManager):
     def _find_subtitle_stream(self, language, is_forced=False):
         # Take in account if a user have enabled Kodi impaired subtitles preference
         # but only without forced setting (same Kodi player behaviour)
-        is_prefer_impaired = self.is_prefer_sub_impaired and not is_forced
+        is_prefer_impaired = common.get_kodi_is_prefer_sub_impaired() and not is_forced
         subtitles_list = self.player_state.get(STREAMS['subtitle']['list'])
         stream = None
         if is_prefer_impaired:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
When Kodi preferred audio setting was set as 'media default'
and the video had two default audio tracks the choice fell on the wrong track

Report on forum: https://forum.kodi.tv/showthread.php?tid=329767&pid=3029851#pid3029851

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
