### PR TITLE
Enabled watched status sync setting by default

### DIFF
--- a/resources/lib/kodi/context_menu.py
+++ b/resources/lib/kodi/context_menu.py
@@ -81,7 +81,7 @@ def generate_context_menu_items(videoid, is_in_mylist, perpetual_range_start=Non
 
     if videoid.mediatype in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
         # Add menu to allow change manually the watched status when progress manager is enabled
-        if G.ADDON.getSettingBool('ProgressManager_enabled'):
+        if G.ADDON.getSettingBool('sync_watched_status'):
             items.insert(0, _ctx_item('change_watched_status', videoid))
 
     return items

--- a/resources/lib/navigation/directory_utils.py
+++ b/resources/lib/navigation/directory_utils.py
@@ -106,7 +106,7 @@ def auto_scroll(dir_items):
     works only with Sync of watched status with netflix
     """
     # A sad implementation to a Kodi feature available only for the Kodi library
-    if G.ADDON.getSettingBool('ProgressManager_enabled') and G.ADDON.getSettingBool('select_first_unwatched'):
+    if G.ADDON.getSettingBool('sync_watched_status') and G.ADDON.getSettingBool('select_first_unwatched'):
         total_items = len(dir_items)
         if total_items:
             # Delay a bit to wait for the completion of the screen update

--- a/resources/lib/navigation/keymaps.py
+++ b/resources/lib/navigation/keymaps.py
@@ -74,7 +74,7 @@ class KeymapsActionExecutor:
         """Change the watched status of a video, only when sync of watched status with NF is enabled"""
         if videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:
             return
-        if G.ADDON.getSettingBool('ProgressManager_enabled'):
+        if G.ADDON.getSettingBool('sync_watched_status'):
             change_watched_status_locally(videoid)
 
     @allow_execution_decorator(inject_videoid=True)

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -149,7 +149,7 @@ def build_episode_listing(episodes_list, seasonid, pathitems=None):
     """Build a episodes listing of a season"""
     common_data = {
         'params': get_param_watched_status_by_profile(),
-        'set_watched_status': G.ADDON.getSettingBool('ProgressManager_enabled'),
+        'set_watched_status': G.ADDON.getSettingBool('sync_watched_status'),
         'supplemental_info_color': get_color_name(G.ADDON.getSettingInt('supplemental_info_color')),
         'profile_language_code': G.LOCAL_DB.get_profile_config('language', ''),
         'active_profile_guid': G.LOCAL_DB.get_active_profile_guid()
@@ -254,7 +254,7 @@ def build_video_listing(video_list, menu_data, sub_genre_id=None, pathitems=None
     common_data = {
         'params': get_param_watched_status_by_profile(),
         'mylist_items': mylist_items,
-        'set_watched_status': G.ADDON.getSettingBool('ProgressManager_enabled'),
+        'set_watched_status': G.ADDON.getSettingBool('sync_watched_status'),
         'supplemental_info_color': get_color_name(G.ADDON.getSettingInt('supplemental_info_color')),
         'mylist_titles_color': (get_color_name(G.ADDON.getSettingInt('mylist_titles_color'))
                                 if menu_data['path'][1] != 'myList'

--- a/resources/lib/services/nfsession/msl/msl_handler.py
+++ b/resources/lib/services/nfsession/msl/msl_handler.py
@@ -111,7 +111,7 @@ class MSLHandler:
         if self.events_handler_thread:
             self.events_handler_thread.stop_join()
             self.events_handler_thread = None
-        if G.ADDON.getSettingBool('ProgressManager_enabled') or override_enable:
+        if G.ADDON.getSettingBool('sync_watched_status') or override_enable:
             self.events_handler_thread = EventsHandler(self.msl_requests.chunked_request, self.nfsession)
             self.events_handler_thread.start()
 

--- a/resources/lib/services/playback/am_playback.py
+++ b/resources/lib/services/playback/am_playback.py
@@ -79,7 +79,7 @@ class AMPlayback(ActionManager):
             return
         if not self.watched_threshold or not player_state['elapsed_seconds'] > self.watched_threshold:
             return
-        if G.ADDON.getSettingBool('ProgressManager_enabled') and not self.is_played_from_strm:
+        if G.ADDON.getSettingBool('sync_watched_status') and not self.is_played_from_strm:
             # This have not to be applied with our custom watched status of Netflix sync, within the addon
             return
         if self.is_played_from_strm:

--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:  # This variable/imports are used only by the editor, so not a
 class AMVideoEvents(ActionManager):
     """Detect the progress of the played video and send the data to the netflix service"""
 
-    SETTING_ID = 'ProgressManager_enabled'
+    SETTING_ID = 'sync_watched_status'
 
     def __init__(self, nfsession: 'NFSessionOperations', msl_handler: 'MSLHandler',
                  directory_builder: 'DirectoryBuilder'):

--- a/resources/lib/services/settings_monitor.py
+++ b/resources/lib/services/settings_monitor.py
@@ -142,8 +142,8 @@ def _check_msl_profiles(clean_buckets):
 
 def _check_watched_status_sync():
     """Check if NF watched status sync setting is changed"""
-    progress_manager_enabled = G.ADDON.getSettingBool('ProgressManager_enabled')
-    progress_manager_enabled_old = G.LOCAL_DB.get_value('progress_manager_enabled', False, TABLE_SETTINGS_MONITOR)
+    progress_manager_enabled = G.ADDON.getSettingBool('sync_watched_status')
+    progress_manager_enabled_old = G.LOCAL_DB.get_value('sync_watched_status', True, TABLE_SETTINGS_MONITOR)
     if progress_manager_enabled != progress_manager_enabled_old:
-        G.LOCAL_DB.set_value('progress_manager_enabled', progress_manager_enabled, TABLE_SETTINGS_MONITOR)
+        G.LOCAL_DB.set_value('sync_watched_status', progress_manager_enabled, TABLE_SETTINGS_MONITOR)
         common.send_signal(common.Signals.SWITCH_EVENTS_HANDLER, progress_manager_enabled)

--- a/resources/lib/upgrade_controller.py
+++ b/resources/lib/upgrade_controller.py
@@ -104,6 +104,12 @@ def _perform_service_changes(previous_ver, current_ver):
         ui.show_ok_dialog('Netflix add-on upgrade',
                           'This add-on upgrade has reset your ESN code, if you had set an ESN code manually '
                           'you must re-enter it again in the Expert settings, otherwise simply ignore this message.')
+    if previous_ver and CmpVersion(previous_ver) < '1.16.0':
+        # In the version 1.16.0 the watched status sync setting has been enabled by default,
+        # therefore to be able to keep the user's setting even when it has never been changed,
+        # we have done a new setting (ProgressManager_enabled >> to >> sync_watched_status)
+        with G.SETTINGS_MONITOR.ignore_events(1):
+            G.ADDON.setSettingBool('sync_watched_status', G.ADDON.getSettingBool('ProgressManager_enabled'))
     # Always leave this to last - After the operations set current version
     G.LOCAL_DB.set_value('service_previous_version', current_ver)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -29,25 +29,31 @@
             </group>
             <!--GROUP: Other options-->
             <group id="3" label="30015">
-                <setting id="ProgressManager_enabled" type="boolean" label="30235" help="">
+                <setting id="ProgressManager_enabled" type="boolean" label="30235" help=""><!--DEPRECATED: kept only for add-on upgrade purpose-->
                     <level>0</level>
                     <default>false</default>
+                    <visible>false</visible>
                     <control type="toggle"/>
                 </setting>
-                <setting id="sync_watched_status_library" type="boolean" label="30301" help="" parent="ProgressManager_enabled">
+                <setting id="sync_watched_status" type="boolean" label="30235" help="">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="sync_watched_status_library" type="boolean" label="30301" help="" parent="sync_watched_status">
                     <level>0</level>
                     <default>false</default>
                     <control type="toggle"/>
                     <dependencies>
-                        <dependency type="visible" setting="ProgressManager_enabled">true</dependency>
+                        <dependency type="visible" setting="sync_watched_status">true</dependency>
                     </dependencies>
                 </setting>
-                <setting id="select_first_unwatched" type="boolean" label="30243" help="" parent="ProgressManager_enabled">
+                <setting id="select_first_unwatched" type="boolean" label="30243" help="" parent="sync_watched_status">
                     <level>0</level>
                     <default>false</default>
                     <control type="toggle"/>
                     <dependencies>
-                        <dependency type="visible" setting="ProgressManager_enabled">true</dependency>
+                        <dependency type="visible" setting="sync_watched_status">true</dependency>
                     </dependencies>
                 </setting>
                 <setting id="mylist_titles_color" type="integer" label="30215" help="">


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
I think this feature has now been widely tested and used,
we can make it enabled by default

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
