### PR TITLE
Convert macrolanguage codes to the primary lang code

### DIFF
--- a/resources/lib/services/nfsession/msl/converter.py
+++ b/resources/lib/services/nfsession/msl/converter.py
@@ -37,8 +37,8 @@ def convert_to_dash(manifest):
     for video_track in manifest['video_tracks']:
         _convert_video_track(video_track, period, init_length, video_protection_info, has_video_drm_streams, cdn_index)
 
-    common.fix_locale_languages(manifest['audio_tracks'])
-    common.fix_locale_languages(manifest['timedtexttracks'])
+    common.apply_lang_code_changes(manifest['audio_tracks'])
+    common.apply_lang_code_changes(manifest['timedtexttracks'])
 
     has_audio_drm_streams = manifest['audio_tracks'][0].get('hasDrmStreams', False)
 

--- a/resources/lib/services/nfsession/msl/msl_utils.py
+++ b/resources/lib/services/nfsession/msl/msl_utils.py
@@ -83,7 +83,7 @@ def update_play_times_duration(play_times, player_state):
 
 def build_media_tag(player_state, manifest):
     """Build the playTimes and the mediaId data by parsing manifest and the current player streams used"""
-    common.fix_locale_languages(manifest['audio_tracks'])
+    common.apply_lang_code_changes(manifest['audio_tracks'])
     duration = player_state['elapsed_seconds'] * 1000
 
     audio_downloadable_id, audio_track_id = _find_audio_data(player_state, manifest)


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improve functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Some languages have his macrolanguage's childs
Kodi handle these macrolanguage codes as an standalone language,
then do not fallback in any way when a lang code is not listed in the played video.

e.g.:
if you set Norwegian (no) and the video played has only the macro lang. Norwegian Bokmål (nb)
the macro language will not be selected, and the user will have to manually select it.

as first solution, this will change all streams macrolanguage codes to his primary lang code,
from the example above, from Norwegian Bokmål (nb) to Norwegian (no),
but only when no streams are listed with Norwegian (no) lang code to prevent duplicates and side effects

Issue #1161 

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
