### PR TITLE
Use f-strings where it makes sense

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,11 @@
 
 #### Types of changes
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Feature change (non-breaking change which change behaviour of an existing functionality)
-- [ ] Improvement (non-breaking change which improve functionality)
+- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
+- [ ] Improvement (non-breaking change which improves functionality)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Refactor (non-breaking performance or readability improvements)
 
 ### Description
 <!--- Motivation and a possible detailed explanation of the changes -->

--- a/resources/lib/common/cache_utils.py
+++ b/resources/lib/common/cache_utils.py
@@ -87,14 +87,14 @@ def _get_identifier(fixed_identifier, identify_from_kwarg_name,
     if fixed_identifier:
         identifier = fixed_identifier
         if identify_append_from_kwarg_name and kwargs.get(identify_append_from_kwarg_name):
-            identifier += '_' + str(kwargs.get(identify_append_from_kwarg_name))
+            identifier += f'_{kwargs.get(identify_append_from_kwarg_name)}'
     else:
         identifier = str(kwargs.get(identify_from_kwarg_name) or '')
         if not identifier and args:
             arg_value = str(args[identify_fallback_arg_index] or '')
             identifier = arg_value
         if identifier and identify_append_from_kwarg_name and kwargs.get(identify_append_from_kwarg_name):
-            identifier += '_' + str(kwargs.get(identify_append_from_kwarg_name))
+            identifier += f'_{kwargs.get(identify_append_from_kwarg_name)}'
     # LOG.debug('Get_identifier identifier value: {}', identifier if identifier else 'None')
     return arg_value, identifier
 

--- a/resources/lib/common/data_conversion.py
+++ b/resources/lib/common/data_conversion.py
@@ -30,7 +30,7 @@ def convert_to_string(value):
     elif data_type in (list, dict, OrderedDict):
         converter = _conv_json_to_string
     else:
-        LOG.error('convert_to_string: Data type {} not mapped'.format(data_type))
+        LOG.error('convert_to_string: Data type {} not mapped', data_type)
         raise DataTypeNotMapped
     return converter(value)
 
@@ -47,7 +47,7 @@ def convert_from_string(value, to_data_type):
     elif to_data_type == datetime.datetime:
         converter = _conv_string_to_datetime
     else:
-        LOG.error('convert_from_string: Data type {} not mapped'.format(to_data_type))
+        LOG.error('convert_from_string: Data type {} not mapped', to_data_type)
         raise DataTypeNotMapped
     return converter(value)
 

--- a/resources/lib/common/device_utils.py
+++ b/resources/lib/common/device_utils.py
@@ -17,8 +17,8 @@ from resources.lib.utils.logging import LOG
 def select_port(service):
     """Select an unused port on the host machine for a server and store it in the settings"""
     port = select_unused_port()
-    G.LOCAL_DB.set_value('{}_service_port'.format(service.lower()), port)
-    LOG.info('[{}] Picked Port: {}'.format(service, port))
+    G.LOCAL_DB.set_value(f'{service.lower()}_service_port', port)
+    LOG.info('[{}] Picked Port: {}', service, port)
     return port
 
 

--- a/resources/lib/common/ipc.py
+++ b/resources/lib/common/ipc.py
@@ -44,7 +44,7 @@ def register_slot(callback, signal=None, source_id=None, is_signal=False):
         signaler_id=source_id or G.ADDON_ID,
         signal=name,
         callback=_callback)
-    LOG.debug('Registered AddonSignals slot {} to {}'.format(name, callback))
+    LOG.debug('Registered AddonSignals slot {} to {}', name, callback)
 
 
 def unregister_slot(callback, signal=None):
@@ -53,7 +53,7 @@ def unregister_slot(callback, signal=None):
     AddonSignals.unRegisterSlot(
         signaler_id=G.ADDON_ID,
         signal=name)
-    LOG.debug('Unregistered AddonSignals slot {}'.format(name))
+    LOG.debug('Unregistered AddonSignals slot {}', name)
 
 
 def send_signal(signal, data=None, non_blocking=False):
@@ -105,8 +105,8 @@ def make_http_call(endpoint, func_name, data=None):
     from urllib.request import build_opener, install_opener, ProxyHandler, urlopen
     from urllib.error import URLError
     # Note: Using 'localhost' as address slowdown the call (Windows OS is affected) not sure if it is an urllib issue
-    url = 'http://127.0.0.1:{}{}/{}'.format(G.LOCAL_DB.get_value('nf_server_service_port'), endpoint, func_name)
-    LOG.debug('Handling HTTP IPC call to {}'.format(url))
+    url = f'http://127.0.0.1:{G.LOCAL_DB.get_value("nf_server_service_port")}{endpoint}/{func_name}'
+    LOG.debug('Handling HTTP IPC call to {}', url)
     install_opener(build_opener(ProxyHandler({})))  # don't use proxy for localhost
     try:
         with urlopen(url=url,
@@ -134,7 +134,7 @@ def make_addonsignals_call(callname, data):
     Make an IPC call via AddonSignals and wait for it to return.
     The contents of data will be expanded to kwargs and passed into the target function.
     """
-    LOG.debug('Handling AddonSignals IPC call to {}'.format(callname))
+    LOG.debug('Handling AddonSignals IPC call to {}', callname)
     _data = b64encode(pickle.dumps(data, pickle.HIGHEST_PROTOCOL)).decode('ascii')
     result = AddonSignals.makeCall(
         source_id=G.ADDON_ID,

--- a/resources/lib/common/kodi_library_ops.py
+++ b/resources/lib/common/kodi_library_ops.py
@@ -33,15 +33,15 @@ LIBRARY_PROPS = {
 
 def update_library_item_details(dbtype, dbid, details):
     """Update properties of an item in the Kodi library"""
-    method = 'VideoLibrary.Set{}Details'.format(dbtype.capitalize())
-    params = {'{}id'.format(dbtype): dbid}
+    method = f'VideoLibrary.Set{dbtype.capitalize()}Details'
+    params = {f'{dbtype}id': dbid}
     params.update(details)
     return json_rpc(method, params)
 
 
 def get_library_items(dbtype, video_filter=None):
     """Return a list of all items in the Kodi library that are of type dbtype (either movie or episode)"""
-    method = 'VideoLibrary.Get{}s'.format(dbtype.capitalize())
+    method = f'VideoLibrary.Get{dbtype.capitalize()}s'
     params = {'properties': ['file']}
     if video_filter:
         params.update({'filter': video_filter})
@@ -50,7 +50,7 @@ def get_library_items(dbtype, video_filter=None):
 
 def get_library_item_details(dbtype, itemid):
     """Return details for an item from the Kodi library"""
-    method = 'VideoLibrary.Get{}Details'.format(dbtype.capitalize())
+    method = f'VideoLibrary.Get{dbtype.capitalize()}Details'
     params = {
         dbtype + 'id': itemid,
         'properties': LIBRARY_PROPS[dbtype]}
@@ -89,7 +89,7 @@ def get_library_item_by_videoid(videoid):
         # Ask to Kodi to find this file path in Kodi library database, and get all item details
         return _get_item_details_from_kodi(media_type, file_path)
     except (KeyError, IndexError, ItemNotFound, DBRecordNotExistError) as exc:
-        raise ItemNotFound('The video with id {} is not present in the Kodi library'.format(videoid)) from exc
+        raise ItemNotFound(f'The video with id {videoid} is not present in the Kodi library') from exc
 
 
 def _get_videoid_file_path(videoid):

--- a/resources/lib/common/kodi_ops.py
+++ b/resources/lib/common/kodi_ops.py
@@ -52,9 +52,7 @@ def json_rpc(method, params=None):
     # debug('JSON-RPC response: {}'.format(raw_response))
     response = json.loads(raw_response)
     if 'error' in response:
-        raise IOError('JSONRPC-Error {}: {}'
-                      .format(response['error']['code'],
-                              response['error']['message']))
+        raise IOError(f'JSONRPC-Error {response["error"]["code"]}: {response["error"]["message"]}')
     return response['result']
 
 
@@ -73,7 +71,7 @@ def json_rpc_multi(method, list_params=None):
     LOG.debug('Executing JSON-RPC: {}', request)
     raw_response = xbmc.executeJSONRPC(request)
     if 'error' in raw_response:
-        raise IOError('JSONRPC-Error {}'.format(raw_response))
+        raise IOError(f'JSONRPC-Error {raw_response}')
     return json.loads(raw_response)
 
 
@@ -91,8 +89,8 @@ def container_refresh(use_delay=False):
 
 def container_update(url, reset_history=False):
     """Update the current container"""
-    func_str = 'Container.Update({},replace)' if reset_history else 'Container.Update({})'
-    xbmc.executebuiltin(func_str.format(url))
+    func_str = f'Container.Update({url},replace)' if reset_history else f'Container.Update({url})'
+    xbmc.executebuiltin(func_str)
 
 
 @contextmanager
@@ -114,7 +112,7 @@ def get_local_string(string_id):
 def run_plugin_action(path, block=False):
     """Create an action that can be run with xbmc.executebuiltin in order to run a Kodi plugin specified by path.
     If block is True (default=False), the execution of code will block until the called plugin has finished running."""
-    return 'RunPlugin({}, {})'.format(path, block)
+    return f'RunPlugin({path}, {block})'
 
 
 def run_plugin(path, block=False):
@@ -125,13 +123,12 @@ def run_plugin(path, block=False):
 
 def schedule_builtin(time, command, name='NetflixTask'):
     """Set an alarm to run builtin command after time has passed"""
-    xbmc.executebuiltin('AlarmClock({},{},{},silent)'
-                        .format(name, command, time))
+    xbmc.executebuiltin(f'AlarmClock({name},{command},{time},silent)')
 
 
 def play_media(media):
     """Play a media in Kodi"""
-    xbmc.executebuiltin('PlayMedia({})'.format(media))
+    xbmc.executebuiltin(f'PlayMedia({media})')
 
 
 def stop_playback():
@@ -167,14 +164,13 @@ class _WndProps:  # pylint: disable=no-init
     def __getitem__(self, key):
         try:
             # If you use multiple Kodi profiles you need to distinguish the property of current profile
-            return G.WND_KODI_HOME.getProperty('netflix_{}_{}'.format(get_current_kodi_profile_name(), key))
+            return G.WND_KODI_HOME.getProperty(f'netflix_{get_current_kodi_profile_name()}_{key}')
         except Exception:  # pylint: disable=broad-except
             return ''
 
     def __setitem__(self, key, newvalue):
         # If you use multiple Kodi profiles you need to distinguish the property of current profile
-        G.WND_KODI_HOME.setProperty('netflix_{}_{}'.format(get_current_kodi_profile_name(), key),
-                                    newvalue)
+        G.WND_KODI_HOME.setProperty(f'netflix_{get_current_kodi_profile_name()}_{key}', newvalue)
 
 
 WndHomeProps = _WndProps()
@@ -271,7 +267,7 @@ def fix_locale_languages(item):
         if item['language'] in LOCALE_CONV_TABLE:
             item['language'] = LOCALE_CONV_TABLE[item['language']]
         else:
-            LOG.error('fix_locale_languages: missing mapping conversion for locale "{}"'.format(item['language']))
+            LOG.error('fix_locale_languages: missing mapping conversion for locale "{}"', item['language'])
 
 
 class KodiVersion(CmpVersion):

--- a/resources/lib/common/misc_utils.py
+++ b/resources/lib/common/misc_utils.py
@@ -66,7 +66,7 @@ def _encode_path(mode, pathitems, videoid):
 
 
 def _encode_params(params):
-    return ('?' + urlencode(params)) if params else ''
+    return f'?{urlencode(params)}' if params else ''
 
 
 def is_numeric(string):
@@ -149,7 +149,7 @@ def any_value_except(mapping, excluded_keys):
 
 
 def enclose_quotes(content):
-    return '"' + content + '"'
+    return f'"{content}"'
 
 
 def make_list(arg):

--- a/resources/lib/common/misc_utils.py
+++ b/resources/lib/common/misc_utils.py
@@ -18,7 +18,7 @@ def find(value_to_find, attribute, search_space):
     for video in search_space:
         if video[attribute] == value_to_find:
             return video
-    raise KeyError('Metadata for {} does not exist'.format(value_to_find))
+    raise KeyError(f'Metadata for {value_to_find} does not exist')
 
 
 def find_episode_metadata(episode_videoid, metadata):
@@ -46,10 +46,7 @@ def build_url(pathitems=None, videoid=None, params=None, mode=None):
     """Build a plugin URL from pathitems and query parameters. Add videoid to the path if it's present."""
     if not (pathitems or videoid):
         raise ValueError('Either pathitems or videoid must be set.')
-    path = '{netloc}/{path}/{qs}'.format(
-        netloc=G.BASE_URL,
-        path=_encode_path(mode, pathitems, videoid),
-        qs=_encode_params(params))
+    path = f'{G.BASE_URL}/{_encode_path(mode, pathitems, videoid)}/{_encode_params(params)}'
     return path
 
 

--- a/resources/lib/common/uuid_device.py
+++ b/resources/lib/common/uuid_device.py
@@ -141,7 +141,7 @@ def _get_macos_uuid():
         if output_data:
             sp_dict_values = _parse_osx_xml_plist_data(output_data)
     except Exception as exc:
-        LOG.debug('Failed to fetch OSX/IOS system profile {}'.format(exc))
+        LOG.debug('Failed to fetch OSX/IOS system profile {}', exc)
     if sp_dict_values:
         if 'UUID' in list(sp_dict_values.keys()):
             return sp_dict_values['UUID']

--- a/resources/lib/common/videoid.py
+++ b/resources/lib/common/videoid.py
@@ -212,7 +212,7 @@ class VideoId:
         of this show. Raises InvalidVideoId is this instance does not
         represent a show."""
         if self.mediatype != VideoId.SHOW:
-            raise InvalidVideoId('Cannot derive season VideoId from {}'.format(self))
+            raise InvalidVideoId(f'Cannot derive season VideoId from {self}')
         return type(self)(tvshowid=self.tvshowid, seasonid=str(seasonid))
 
     def derive_episode(self, episodeid):
@@ -220,7 +220,7 @@ class VideoId:
         of this season. Raises InvalidVideoId is this instance does not
         represent a season."""
         if self.mediatype != VideoId.SEASON:
-            raise InvalidVideoId('Cannot derive episode VideoId from {}'.format(self))
+            raise InvalidVideoId(f'Cannot derive episode VideoId from {self}')
         return type(self)(tvshowid=self.tvshowid, seasonid=self.seasonid,
                           episodeid=str(episodeid))
 
@@ -243,7 +243,7 @@ class VideoId:
                 return self
             return type(self)(tvshowid=self.tvshowid,
                               seasonid=self.seasonid)
-        raise InvalidVideoId('VideoId type {} not valid'.format(videoid_type))
+        raise InvalidVideoId(f'VideoId type {videoid_type} not valid')
 
     def _assigned_id_values(self):
         """Return a list of all id_values that are not None"""
@@ -252,7 +252,7 @@ class VideoId:
                 if id_value is not None]
 
     def __str__(self):
-        return '{}_{}'.format(self.mediatype, self.value)
+        return f'{self.mediatype}_{self.value}'
 
     def __hash__(self):
         return hash(str(self))
@@ -267,7 +267,7 @@ class VideoId:
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'VideoId object [{}]'.format(self)
+        return f'VideoId object [{self}]'
 
 
 def _get_unicode_kwargs(kwargs):
@@ -303,7 +303,7 @@ def inject_video_id(path_offset, pathitems_arg='pathitems',
                 _path_to_videoid(kwargs, pathitems_arg, path_offset,
                                  inject_remaining_pathitems, inject_full_pathitems)
             except KeyError as exc:
-                raise Exception('Pathitems must be passed as kwarg {}'.format(pathitems_arg)) from exc
+                raise Exception(f'Pathitems must be passed as kwarg {pathitems_arg}') from exc
             return func(*args, **kwargs)
         return wrapper
     return injecting_decorator

--- a/resources/lib/database/db_base_mysql.py
+++ b/resources/lib/database/db_base_mysql.py
@@ -161,9 +161,7 @@ class MySQLDatabase(db_base.BaseDatabase):
         """
         table_name = table[0]
         table_columns = table[1]
-        query = 'SELECT {} FROM {} WHERE {} = ?'.format(table_columns[1],
-                                                        table_name,
-                                                        table_columns[0])
+        query = f'SELECT {table_columns[1]} FROM {table_name} WHERE {table_columns[0]} = ?'
         cur = self._execute_query(query, (key,))
         result = cur.fetchone()
         if default_value is not None:
@@ -184,9 +182,7 @@ class MySQLDatabase(db_base.BaseDatabase):
         """
         table_name = table[0]
         table_columns = table[1]
-        query = 'SELECT {} FROM {} WHERE {} = ?'.format(table_columns[1],
-                                                        table_name,
-                                                        table_columns[0])
+        query = f'SELECT {table_columns[1]} FROM {table_name} WHERE {table_columns[0]} = ?'
         cur = self._execute_query(query, (key,))
         result = cur.fetchall()
         return result if result is not None else default_value
@@ -216,7 +212,7 @@ class MySQLDatabase(db_base.BaseDatabase):
         """
         table_name = table[0]
         table_columns = table[1]
-        query = 'DELETE FROM {} WHERE {} = ?'.format(table_name, table_columns[0])
+        query = f'DELETE FROM {table_name} WHERE {table_columns[0]} = ?'
         cur = self._execute_query(query, (key,))
         return cur.rowcount
 

--- a/resources/lib/database/db_base_sqlite.py
+++ b/resources/lib/database/db_base_sqlite.py
@@ -174,9 +174,7 @@ class SQLiteDatabase(db_base.BaseDatabase):
         """
         table_name = table[0]
         table_columns = table[1]
-        query = 'SELECT {} FROM {} WHERE {} = ?'.format(table_columns[1],
-                                                        table_name,
-                                                        table_columns[0])
+        query = f'SELECT {table_columns[1]} FROM {table_name} WHERE {table_columns[0]} = ?'
         cur = self._execute_query(query, (key,))
         result = cur.fetchone()
         if default_value is not None:
@@ -197,9 +195,7 @@ class SQLiteDatabase(db_base.BaseDatabase):
         """
         table_name = table[0]
         table_columns = table[1]
-        query = 'SELECT {} FROM {} WHERE {} = ?'.format(table_columns[1],
-                                                        table_name,
-                                                        table_columns[0])
+        query = f'SELECT {table_columns[1]} FROM {table_name} WHERE {table_columns[0]} = ?'
         cur = self._execute_query(query, (key,))
         result = cur.fetchall()
         return result if result is not None else default_value
@@ -215,14 +211,11 @@ class SQLiteDatabase(db_base.BaseDatabase):
         table_name = table[0]
         table_columns = table[1]
         # Update or insert approach, if there is no updated row then insert new one (no id changes)
-        update_query = 'UPDATE {} SET {} = ? WHERE {} = ?'.format(table_name,
-                                                                  table_columns[1],
-                                                                  table_columns[0])
+        update_query = f'UPDATE {table_name} SET {table_columns[1]} = ? WHERE {table_columns[0]} = ?'
         value = common.convert_to_string(value)
         cur = self._execute_query(update_query, (value, key))
         if cur.rowcount == 0:
-            insert_query = 'INSERT INTO {} ({}, {}) VALUES (?, ?)'\
-                .format(table_name, table_columns[0], table_columns[1])
+            insert_query = f'INSERT INTO {table_name} ({table_columns[0]}, {table_columns[1]}) VALUES (?, ?)'
             self._execute_non_query(insert_query, (key, value))
 
     @handle_connection
@@ -237,17 +230,13 @@ class SQLiteDatabase(db_base.BaseDatabase):
         # Doing many sqlite operations at the same makes the performance much worse (especially on Kodi 18)
         # The use of 'executemany' and 'transaction' can improve performance up to about 75% !!
         if common.CmpVersion(sql.sqlite_version) < '3.24.0':
-            query = 'INSERT OR REPLACE INTO {} ({}, {}) VALUES (?, ?)'.format(table_name,
-                                                                              table_columns[0],
-                                                                              table_columns[1])
+            query = f'INSERT OR REPLACE INTO {table_name} ({table_columns[0]}, {table_columns[1]}) VALUES (?, ?)'
             records_values = [(key, common.convert_to_string(value)) for key, value in dict_values.items()]
         else:
             # sqlite UPSERT clause exists only on sqlite >= 3.24.0
-            query = ('INSERT INTO {tbl_name} ({tbl_col1}, {tbl_col2}) VALUES (?, ?) '
-                     'ON CONFLICT({tbl_col1}) DO UPDATE SET {tbl_col2} = ? '
-                     'WHERE {tbl_col1} = ?').format(tbl_name=table_name,
-                                                    tbl_col1=table_columns[0],
-                                                    tbl_col2=table_columns[1])
+            query = (f'INSERT INTO {table_name} ({table_columns[0]}, {table_columns[1]}) VALUES (?, ?) '
+                     f'ON CONFLICT({table_columns[0]}) DO UPDATE SET {table_columns[1]} = ? '
+                     f'WHERE {table_columns[0]} = ?')
             records_values = []
             for key, value in dict_values.items():
                 value_str = common.convert_to_string(value)
@@ -267,7 +256,7 @@ class SQLiteDatabase(db_base.BaseDatabase):
         """
         table_name = table[0]
         table_columns = table[1]
-        query = 'DELETE FROM {} WHERE {} = ?'.format(table_name, table_columns[0])
+        query = f'DELETE FROM {table_name} WHERE {table_columns[0]} = ?'
         cur = self._execute_query(query, (key,))
         return cur.rowcount
 

--- a/resources/lib/database/db_shared.py
+++ b/resources/lib/database/db_shared.py
@@ -188,7 +188,7 @@ def get_shareddb_class(use_mysql=False):
             cur = self.get_cursor_for_list_results()
             if enum_vid_prop and prop_value:
                 query = ('SELECT TvShowID FROM video_lib_tvshows '
-                         'WHERE ' + enum_vid_prop + ' = ?')
+                         f'WHERE {enum_vid_prop} = ?')
                 cur = self._execute_query(query, (str(prop_value),), cur)
             else:
                 query = 'SELECT TvShowID FROM video_lib_tvshows'
@@ -358,7 +358,7 @@ def get_shareddb_class(use_mysql=False):
             :param data_type: OPTIONAL Used to set data type conversion only when default_value is None
             :return: the property value
             """
-            query = 'SELECT ' + enum_vid_prop + ' FROM video_lib_tvshows WHERE TvShowID = ?'
+            query = f'SELECT {enum_vid_prop} FROM video_lib_tvshows WHERE TvShowID = ?'
             cur = self._execute_query(query, (tvshowid,))
             result = cur.fetchone()
             if default_value is not None:
@@ -372,7 +372,7 @@ def get_shareddb_class(use_mysql=False):
         @db_base_sqlite.handle_connection
         def set_tvshow_property(self, tvshowid, enum_vid_prop, value):
             update_query = ('UPDATE video_lib_tvshows '
-                            'SET ' + enum_vid_prop + ' = ? WHERE TvShowID = ?')
+                            f'SET {enum_vid_prop} = ? WHERE TvShowID = ?')
             value = common.convert_to_string(value)
             self._execute_query(update_query, (value, tvshowid))
 

--- a/resources/lib/database/db_shared.py
+++ b/resources/lib/database/db_shared.py
@@ -141,7 +141,7 @@ def get_shareddb_class(use_mysql=False):
                  'INNER JOIN video_lib_seasons '
                  'ON video_lib_episodes.SeasonID = video_lib_seasons.SeasonID '
                  'WHERE video_lib_seasons.TvShowID = ? '
-                 'ORDER BY {} LIMIT 1').format(rand_func_name)
+                 f'ORDER BY {rand_func_name} LIMIT 1')
             cur = self._execute_query(query, (tvshowid,))
             result = cur.fetchone()
             if not result:
@@ -158,7 +158,7 @@ def get_shareddb_class(use_mysql=False):
                  'INNER JOIN video_lib_seasons '
                  'ON video_lib_episodes.SeasonID = video_lib_seasons.SeasonID '
                  'WHERE video_lib_seasons.TvShowID = ? AND video_lib_seasons.SeasonID = ? '
-                 'ORDER BY {} LIMIT 1').format(rand_func_name)
+                 f'ORDER BY {rand_func_name} LIMIT 1')
             cur = self._execute_query(query, (tvshowid, seasonid))
             result = cur.fetchone()
             if not result:

--- a/resources/lib/database/db_utils.py
+++ b/resources/lib/database/db_utils.py
@@ -54,12 +54,10 @@ def sql_filtered_update(table, set_columns, where_columns, values):
             del set_columns[index]
             del values[index]
     set_columns = [col + ' = ?' for col in set_columns]
+    columns_to_set = ', '.join(set_columns)
     where_columns = [col + ' = ?' for col in where_columns]
-    query = 'UPDATE {} SET {} WHERE {}'.format(
-        table,
-        ', '.join(set_columns),
-        ' AND '.join(where_columns)
-    )
+    where_condition = ' AND '.join(where_columns)
+    query = f'UPDATE {table} SET {columns_to_set} WHERE {where_condition}'
     return query, values
 
 
@@ -75,11 +73,9 @@ def sql_filtered_insert(table, set_columns, values):
             del set_columns[index]
             del values[index]
     values_fields = ['?'] * len(set_columns)
-    query = 'INSERT INTO {} ({}) VALUES ({})'.format(
-        table,
-        ', '.join(set_columns),
-        ', '.join(values_fields)
-    )
+    query_columns = ', '.join(set_columns)
+    values = ', '.join(values_fields)
+    query = f'INSERT INTO {table} ({query_columns}) VALUES ({values})'
     return query, values
 
 
@@ -90,11 +86,12 @@ def mysql_insert_or_update(table, id_columns, columns):
     columns[0:0] = id_columns
     sets_columns = ['@' + col for col in columns]
     sets = [col + ' = %s' for col in sets_columns]
-    query_set = 'SET {};'.format(', '.join(sets))
-    query_insert = 'INSERT INTO {} ({}) VALUES ({})'.format(table,
-                                                            ', '.join(columns),
-                                                            ', '.join(sets_columns))
+    query_set = f'SET {", ".join(sets)};'
+    query_columns = ', '.join(columns)
+    values = ', '.join(sets_columns)
+    query_insert = f'INSERT INTO {table} ({query_columns}) VALUES ({values})'
+
     columns = list(set(columns) - set(id_columns))  # Fastest method to remove list to list tested
     on_duplicate_params = [col + ' = @' + col for col in columns]
-    query_duplicate = 'ON DUPLICATE KEY UPDATE {}'.format(', '.join(on_duplicate_params)) + ';'
+    query_duplicate = f'ON DUPLICATE KEY UPDATE {", ".join(on_duplicate_params)};'
     return ' '.join([query_set, query_insert, query_duplicate])

--- a/resources/lib/database/db_utils.py
+++ b/resources/lib/database/db_utils.py
@@ -84,14 +84,14 @@ def mysql_insert_or_update(table, id_columns, columns):
     Create a MySQL insert or update query (required multi=True)
     """
     columns[0:0] = id_columns
-    sets_columns = ['@' + col for col in columns]
-    sets = [col + ' = %s' for col in sets_columns]
+    sets_columns = [f'@{col}' for col in columns]
+    sets = [f'{col} = %s' for col in sets_columns]
     query_set = f'SET {", ".join(sets)};'
     query_columns = ', '.join(columns)
     values = ', '.join(sets_columns)
     query_insert = f'INSERT INTO {table} ({query_columns}) VALUES ({values})'
 
     columns = list(set(columns) - set(id_columns))  # Fastest method to remove list to list tested
-    on_duplicate_params = [col + ' = @' + col for col in columns]
+    on_duplicate_params = [f'{col} = @{col}' for col in columns]
     query_duplicate = f'ON DUPLICATE KEY UPDATE {", ".join(on_duplicate_params)};'
     return ' '.join([query_set, query_insert, query_duplicate])

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -235,13 +235,11 @@ class GlobalVariables:
             try:
                 self.PLUGIN_HANDLE = int(argv[1])
                 self.IS_SERVICE = False
-                self.BASE_URL = '{scheme}://{netloc}'.format(scheme=self.URL[0],
-                                                             netloc=self.URL[1])
+                self.BASE_URL = f'{self.URL[0]}://{self.URL[1]}'
             except IndexError:
                 self.PLUGIN_HANDLE = 0
                 self.IS_SERVICE = True
-                self.BASE_URL = '{scheme}://{netloc}'.format(scheme='plugin',
-                                                             netloc=self.ADDON_ID)
+                self.BASE_URL = f'plugin://{self.ADDON_ID}'
             from resources.lib.common.kodi_ops import KodiVersion
             self.KODI_VERSION = KodiVersion()
         # Initialize the log

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -42,7 +42,7 @@ MEDIA_TYPE_MAPPINGS = {
 
 def get_info(videoid, item, raw_data, profile_language_code='', delayed_db_op=False):
     """Get the infolabels data"""
-    cache_identifier = videoid.value + '_' + profile_language_code
+    cache_identifier = f'{videoid.value}_{profile_language_code}'
     try:
         cache_entry = G.CACHE.get(CACHE_INFOLABELS, cache_identifier)
         infos = cache_entry['infos']
@@ -103,7 +103,7 @@ def _add_supplemental_plot_info(infos_copy, item, common_data):
 
 def get_art(videoid, item, profile_language_code='', delayed_db_op=False):
     """Get art infolabels - NOTE: If 'item' arg is None this method can raise TypeError when there is not cache"""
-    cache_identifier = videoid.value + '_' + profile_language_code
+    cache_identifier = f'{videoid.value}_{profile_language_code}'
     try:
         art = G.CACHE.get(CACHE_ARTINFO, cache_identifier)
     except CacheMiss:

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -247,10 +247,10 @@ def _best_art(arts):
 def get_info_from_library(videoid):
     """Get infolabels with info from Kodi library"""
     details = common.get_library_item_by_videoid(videoid)
-    LOG.debug('Got file info from library: {}'.format(details))
+    LOG.debug('Got file info from library: {}', details)
     art = details.pop('art', {})
     infos = {
-        'DBID': details.pop('{}id'.format(videoid.mediatype)),
+        'DBID': details.pop(f'{videoid.mediatype}id'),
         'MediaType': MEDIA_TYPE_MAPPINGS[videoid.mediatype]
     }
     infos.update(details)
@@ -259,7 +259,7 @@ def get_info_from_library(videoid):
 
 def _colorize_text(color_name, text):
     if color_name:
-        return '[COLOR {}]{}[/COLOR]'.format(color_name, text)
+        return f'[COLOR {color_name}]{text}[/COLOR]'
     return text
 
 

--- a/resources/lib/kodi/library.py
+++ b/resources/lib/kodi/library.py
@@ -279,7 +279,7 @@ class Library(LibraryTasks):
                                                                            task_handler,
                                                                            nfo_settings=nfo_settings,
                                                                            notify_errors=show_prg_dialog):
-                    label_partial_op = ' ({}/{})'.format(index + 1, total_tasks) if total_tasks > 1 else ''
+                    label_partial_op = f' ({index + 1}/{total_tasks})' if total_tasks > 1 else ''
                     progress_bar.set_message(title + label_partial_op)
                 if progress_bar.is_cancelled():
                     LOG.warn('Auto update of the Kodi library interrupted by User')
@@ -325,7 +325,7 @@ class Library(LibraryTasks):
                                                                                self.export_item,
                                                                                nfo_settings=nfo_settings,
                                                                                notify_errors=True):
-                        label_partial_op = ' ({}/{})'.format(index + 1, total_tasks) if total_tasks > 1 else ''
+                        label_partial_op = f' ({index + 1}/{total_tasks})' if total_tasks > 1 else ''
                         progress_bar.set_message(title + label_partial_op)
                     if progress_bar.is_cancelled():
                         LOG.warn('Import library interrupted by User')
@@ -357,7 +357,7 @@ class Library(LibraryTasks):
         LOG.info('Start deleting folders')
         with ui.ProgressDialog(True, max_value=tot_folders) as progress_bar:
             for file_path in remove_folders:
-                progress_bar.set_message('{}/{}'.format(progress_bar.value, tot_folders))
+                progress_bar.set_message(f'{progress_bar.value}/{tot_folders}')
                 LOG.debug('Deleting folder: {}', file_path)
                 common.delete_folder(file_path)
                 progress_bar.perform_step()

--- a/resources/lib/kodi/library_tasks.py
+++ b/resources/lib/kodi/library_tasks.py
@@ -87,7 +87,7 @@ class LibraryTasks(LibraryJobs):
             LOG.error(traceback.format_exc())
             LOG.error('{} of {} ({}) failed', job_handler.__name__, job_data['videoid'], job_data['title'])
             list_errors.append({'title': job_data['title'],
-                                'error': '{}: {}'.format(type(exc).__name__, exc)})
+                                'error': f'{type(exc).__name__}: {exc}'})
 
     @measure_exec_time_decorator(is_immediate=True)
     def compile_jobs_data(self, videoid, task_type, nfo_settings=None):
@@ -127,7 +127,7 @@ class LibraryTasks(LibraryJobs):
     def _create_export_movie_job(self, videoid, movie, nfo_settings):
         """Create job data to export a movie"""
         # Reset NFO export to false if we never want movies nfo
-        filename = '{title} ({year})'.format(title=movie['title'], year=movie['year'])
+        filename = f'{movie["title"]} ({movie["year"]})'
         create_nfo_file = nfo_settings and nfo_settings.export_movie_enabled
         nfo_data = nfo.create_movie_nfo(movie) if create_nfo_file else None
         return self._build_export_job_data(True, create_nfo_file,

--- a/resources/lib/kodi/library_utils.py
+++ b/resources/lib/kodi/library_utils.py
@@ -75,13 +75,13 @@ def is_videoid_in_db(videoid):
         return G.SHARED_DB.episode_id_exists(videoid.tvshowid,
                                              videoid.seasonid,
                                              videoid.episodeid)
-    raise InvalidVideoId('videoid {} type not implemented'.format(videoid))
+    raise InvalidVideoId(f'videoid {videoid} type not implemented')
 
 
 def get_episode_title_from_path(file_path):
     filename = os.path.splitext(os.path.basename(file_path))[0]
     path = os.path.split(os.path.split(file_path)[0])[1]
-    return '{} - {}'.format(path, filename)
+    return f'{path} - {filename}'
 
 
 def get_nfo_settings():

--- a/resources/lib/kodi/nfo.py
+++ b/resources/lib/kodi/nfo.py
@@ -80,7 +80,7 @@ class NFOSettings:
             if self.tvshow_prompt_dialog:
                 ask_message_typelist.append(common.get_local_string(30190))
         if ask_message_typelist:
-            message = ' {} '.format(common.get_local_string(1397)).join(ask_message_typelist)
+            message = f' {common.get_local_string(1397)} '.join(ask_message_typelist)
             message = common.get_local_string(30183).format(message) + common.get_local_string(30192)
             user_choice = ui.ask_for_confirmation(common.get_local_string(30182), message)
             if len(ask_message_typelist) == 2 and not user_choice:

--- a/resources/lib/kodi/ui/dialogs.py
+++ b/resources/lib/kodi/ui/dialogs.py
@@ -91,7 +91,7 @@ def ask_for_resume(resume_position):
 def show_backend_not_ready(error_details=None):
     message = common.get_local_string(30138)
     if error_details:
-        message += '[CR][CR]Error details:[CR]' + error_details
+        message += f'[CR][CR]Error details:[CR]{error_details}'
     return xbmcgui.Dialog().ok(common.get_local_string(30105), message)
 
 

--- a/resources/lib/kodi/ui/dialogs.py
+++ b/resources/lib/kodi/ui/dialogs.py
@@ -16,7 +16,7 @@ import resources.lib.common as common
 
 def show_notification(msg, title='Netflix', time=3000):
     """Show a notification"""
-    xbmc.executebuiltin('Notification({}, {}, {}, {})'.format(title, msg, time, G.ICON))
+    xbmc.executebuiltin(f'Notification({title}, {msg}, {time}, {G.ICON})')
 
 
 def ask_credentials():
@@ -45,8 +45,7 @@ def ask_for_password():
 
 def ask_for_rating():
     """Ask the user for a rating"""
-    heading = '{} {}'.format(common.get_local_string(30019),
-                             common.get_local_string(30022))
+    heading = f'{common.get_local_string(30019)} {common.get_local_string(30022)}'
     try:
         return int(xbmcgui.Dialog().numeric(heading=heading, type=0,
                                             defaultt=''))
@@ -127,7 +126,7 @@ def show_addon_error_info(exc):
 def show_library_task_errors(notify_errors, errors):
     if notify_errors and errors:
         xbmcgui.Dialog().ok(common.get_local_string(0),
-                            '[CR]'.join(['{} ({})'.format(err['title'], err['error'])
+                            '[CR]'.join([f'{err["title"]} ({err["error"]})'
                                          for err in errors]))
 
 

--- a/resources/lib/kodi/ui/xmldialog_esnwidevine.py
+++ b/resources/lib/kodi/ui/xmldialog_esnwidevine.py
@@ -233,9 +233,9 @@ def _save_system_info():
                 data += '\n>>> Suggested solutions:'
                 data += '\n>>> - Restore a previous version of Widevine library from InputStream Helper add-on settings'
                 data += '\n>>> - Report the problem to the GitHub of InputStream Helper add-on'
-                data += '\n>>> Error details: {}'.format(exc)
+                data += f'\n>>> Error details: {exc}'
         except Exception as exc:  # pylint: disable=broad-except
-            data += '\nThe data could not be obtained. Error details: {}'.format(exc)
+            data += f'\nThe data could not be obtained. Error details: {exc}'
     data += '\n\n' + '#### ESN ####\n'
     esn = get_esn() or '--not obtained--'
     data += '\nUsed ESN: ' + common.censure(esn) if len(esn) > 50 else esn
@@ -248,11 +248,11 @@ def _save_system_info():
             info = subprocess.check_output(['/system/bin/getprop']).decode('utf-8')
             data += '\n' + info
         except Exception as exc:  # pylint: disable=broad-except
-            data += '\nThe data could not be obtained. Error: {}'.format(exc)
+            data += f'\nThe data could not be obtained. Error: {exc}'
     data += '\n'
     try:
         common.save_file(common.join_folders_paths(path, filename), data.encode('utf-8'))
-        ui.show_notification('{}: {}'.format(xbmc.getLocalizedString(35259), filename))  # 35259=Saved
+        ui.show_notification(f'{xbmc.getLocalizedString(35259)}: {filename}')  # 35259=Saved
     except Exception as exc:  # pylint: disable=broad-except
         LOG.error('save_file error: {}', exc)
         ui.show_notification('Error! Try another path')
@@ -276,5 +276,5 @@ def _get_cdm_file_path():
     addon = Addon('inputstream.adaptive')
     cdm_path = xbmcvfs.translatePath(addon.getSetting('DECRYPTERPATH'))
     if not common.folder_exists(cdm_path):
-        raise Exception('The CDM path {} not exists'.format(cdm_path))
+        raise Exception(f'The CDM path {cdm_path} not exists')
     return common.join_folders_paths(cdm_path, lib_filename)

--- a/resources/lib/kodi/ui/xmldialog_esnwidevine.py
+++ b/resources/lib/kodi/ui/xmldialog_esnwidevine.py
@@ -194,23 +194,23 @@ class ESNWidevine(xbmcgui.WindowXMLDialog):
 def _save_system_info():
     # Ask to save to a file
     filename = 'NFSystemInfo.txt'
-    path = ui.show_browse_dialog(common.get_local_string(30603) + ' - ' + filename)
+    path = ui.show_browse_dialog(f'{common.get_local_string(30603)} - {filename}')
     if not path:
         return
     # This collect the main data to allow verification checks for problems
-    data = 'Netflix add-on version: ' + G.VERSION
-    data += '\nDebug enabled: ' + str(LOG.is_enabled)
-    data += '\nSystem platform: ' + common.get_system_platform()
-    data += '\nMachine architecture: ' + common.get_machine()
-    data += '\nUser agent string: ' + common.get_user_agent()
-    data += '\n\n' + '#### Widevine info ####\n'
+    data = f'Netflix add-on version: {G.VERSION}'
+    data += f'\nDebug enabled: {LOG.is_enabled}'
+    data += f'\nSystem platform: {common.get_system_platform()}'
+    data += f'\nMachine architecture: {common.get_machine()}'
+    data += f'\nUser agent string: {common.get_user_agent()}'
+    data += '\n\n#### Widevine info ####\n'
     if common.get_system_platform() == 'android':
-        data += '\nSystem ID: ' + G.LOCAL_DB.get_value('drm_system_id', '--not obtained--', TABLE_SESSION)
-        data += '\nSecurity level: ' + G.LOCAL_DB.get_value('drm_security_level', '--not obtained--', TABLE_SESSION)
-        data += '\nHDCP level: ' + G.LOCAL_DB.get_value('drm_hdcp_level', '--not obtained--', TABLE_SESSION)
+        data += f'\nSystem ID: {G.LOCAL_DB.get_value("drm_system_id", "--not obtained--", TABLE_SESSION)}'
+        data += f'\nSecurity level: {G.LOCAL_DB.get_value("drm_security_level", "--not obtained--", TABLE_SESSION)}'
+        data += f'\nHDCP level: {G.LOCAL_DB.get_value("drm_hdcp_level", "--not obtained--", TABLE_SESSION)}'
         wv_force_sec_lev = G.LOCAL_DB.get_value('widevine_force_seclev', WidevineForceSecLev.DISABLED,
                                                 TABLE_SESSION)
-        data += '\nForced security level setting is: ' + wv_force_sec_lev
+        data += f'\nForced security level setting is: {wv_force_sec_lev}'
     else:
         try:
             from ctypes import (CDLL, c_char_p)
@@ -220,7 +220,7 @@ def _save_system_info():
                 data += '\nLibrary status: Correctly loaded'
                 try:
                     lib.GetCdmVersion.restype = c_char_p
-                    data += '\nVersion: ' + lib.GetCdmVersion().decode('utf-8')
+                    data += f'\nVersion: {lib.GetCdmVersion().decode("utf-8")}'
                 except Exception:  # pylint: disable=broad-except
                     # This can happen if the endpoint 'GetCdmVersion' is changed
                     data += '\nVersion: Reading error'
@@ -236,17 +236,17 @@ def _save_system_info():
                 data += f'\n>>> Error details: {exc}'
         except Exception as exc:  # pylint: disable=broad-except
             data += f'\nThe data could not be obtained. Error details: {exc}'
-    data += '\n\n' + '#### ESN ####\n'
+    data += '\n\n#### ESN ####\n'
     esn = get_esn() or '--not obtained--'
-    data += '\nUsed ESN: ' + common.censure(esn) if len(esn) > 50 else esn
-    data += '\nWebsite ESN: ' + (get_website_esn() or '--not obtained--')
-    data += '\nAndroid generated ESN: ' + (generate_android_esn() or '--not obtained--')
+    data += f'\nUsed ESN: {common.censure(esn) if len(esn) > 50 else esn}'
+    data += f'\nWebsite ESN: {get_website_esn() or "--not obtained--"}'
+    data += f'\nAndroid generated ESN: {(generate_android_esn() or "--not obtained--")}'
     if common.get_system_platform() == 'android':
-        data += '\n\n' + '#### Device system info ####\n'
+        data += '\n\n#### Device system info ####\n'
         try:
             import subprocess
             info = subprocess.check_output(['/system/bin/getprop']).decode('utf-8')
-            data += '\n' + info
+            data += f'\n{info}'
         except Exception as exc:  # pylint: disable=broad-except
             data += f'\nThe data could not be obtained. Error: {exc}'
     data += '\n'

--- a/resources/lib/kodi/ui/xmldialog_parental.py
+++ b/resources/lib/kodi/ui/xmldialog_parental.py
@@ -93,8 +93,8 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
         self.current_level_index = self.getControl(10004).getInt() if new_level_index is None else new_level_index
         # Update labels color of slider steps
         for index in range(0, self.levels_count):
-            maturity_name = '[' + self.rating_levels[index]['label'] + ']'
-            ml_label = '[COLOR red]{}[/COLOR]'.format(maturity_name) if index <= self.current_level_index else maturity_name
+            maturity_name = f'[{self.rating_levels[index]["label"]}]'
+            ml_label = f'[COLOR red]{maturity_name}[/COLOR]' if index <= self.current_level_index else maturity_name
             self.controls[index].setLabel(ml_label)
         # Update status description
         hint = self.rating_levels[self.current_level_index]['description']

--- a/resources/lib/kodi/ui/xmldialog_parental.py
+++ b/resources/lib/kodi/ui/xmldialog_parental.py
@@ -99,7 +99,7 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
         # Update status description
         hint = self.rating_levels[self.current_level_index]['description']
         ml_labels_included = [self.rating_levels[index]['label'] for index in range(0, self.current_level_index + 1)]
-        status_desc = self.status_base_desc.format(', '.join(ml_labels_included)) + '[CR]' + hint
+        status_desc = self.status_base_desc.format(', '.join(ml_labels_included)) + f'[CR]{hint}'
         self.getControl(10009).setLabel(status_desc)
 
     # def _validate_pin(self, pin_value):
@@ -117,7 +117,7 @@ class ParentalControl(xbmcgui.WindowXMLDialog):
         pos_y = 508  # 668
         for index, rating_level in enumerate(self.rating_levels):
             current_x = pos_x + (width * index)
-            maturity_name = '[' + rating_level['label'] + ']'
+            maturity_name = f'[{rating_level["label"]}]'
             lbl = xbmcgui.ControlLabel(current_x, pos_y, width, height, maturity_name,
                                        font='font10',
                                        alignment=XBFONT_CENTER_X)

--- a/resources/lib/kodi/ui/xmldialogs.py
+++ b/resources/lib/kodi/ui/xmldialogs.py
@@ -120,7 +120,7 @@ def show_profiles_dialog(title=None, title_prefix=None, preselect_guid=None):
     if not title:
         title = G.ADDON.getLocalizedString(30128)
     if title_prefix:
-        title = title_prefix + ' - ' + title
+        title = f'{title_prefix} - {title}'
     # Get profiles data
     # pylint: disable=unused-variable
     dir_items, extra_data = make_call('get_profiles',

--- a/resources/lib/navigation/actions.py
+++ b/resources/lib/navigation/actions.py
@@ -119,7 +119,7 @@ class AddonActionExecutor:
         # This functionality is used with videos that are not available,
         # allows you to automatically add the title to my list as soon as it becomes available.
         operation = pathitems[1]
-        G.CACHE.add(CACHE_BOOKMARKS, 'is_in_remind_me_' + str(videoid), bool(operation == 'add'))
+        G.CACHE.add(CACHE_BOOKMARKS, f'is_in_remind_me_{videoid}', bool(operation == 'add'))
         api.update_remindme(operation, videoid, self.params['trackid'])
         common.container_refresh()
 
@@ -218,7 +218,7 @@ class AddonActionExecutor:
             xbmc.getInfoLabel('ListItem.Property(nf_availability_message)') or '--')
         if trailer_path:
             if ui.show_yesno_dialog(xbmc.getInfoLabel('ListItem.Label'),
-                                    msg + '[CR]' + common.get_local_string(30621),
+                                    f'{msg}[CR]{common.get_local_string(30621)}',
                                     default_yes_button=True):
                 # Create a basic trailer ListItem (all other info if available are set on Play callback)
                 list_item = xbmcgui.ListItem(xbmc.getInfoLabel('ListItem.Title'), offscreen=True)

--- a/resources/lib/navigation/directory_search.py
+++ b/resources/lib/navigation/directory_search.py
@@ -89,7 +89,7 @@ def search_add():
         if genre_id:
             row_id = _search_add_bygenreid(SEARCH_TYPES[type_index], genre_id)
     else:
-        raise NotImplementedError('Search type index {} not implemented'.format(type_index))
+        raise NotImplementedError(f'Search type index {type_index} not implemented')
     # Redirect to "search" endpoint (otherwise no results in JSON-RPC)
     # Rewrite path history using dir_update_listing + container_update
     # (otherwise will retrigger input dialog on Back or Container.Refresh)
@@ -121,7 +121,7 @@ def _search_add_bygenreid(search_type, genre_id):
         ui.show_notification(common.get_local_string(30407))
         return None
     # In this case the 'value' is used only as title for the ListItem and not for the query
-    title += ' [{}]'.format(genre_id)
+    title += f' [{genre_id}]'
     row_id = G.LOCAL_DB.insert_search_item(search_type, title, {'genre_id': genre_id})
     return row_id
 
@@ -208,7 +208,7 @@ def search_query(row_id, perpetual_range_start, dir_update_listing):
         }
         dir_items, extra_data = common.make_call('get_video_list_sorted_sp', call_args)
     else:
-        raise NotImplementedError('Search type {} not implemented'.format(search_type))
+        raise NotImplementedError(f'Search type {search_type} not implemented')
     # Show the results
     if not dir_items:
         ui.show_notification(common.get_local_string(30407))

--- a/resources/lib/navigation/directory_search.py
+++ b/resources/lib/navigation/directory_search.py
@@ -102,14 +102,14 @@ def search_add():
 
 def _search_add_bylang(search_type, dict_languages):
     search_type_desc = SEARCH_TYPES_DESC.get(search_type, 'Unknown')
-    title = search_type_desc + ' - ' + common.get_local_string(30405)
+    title = f'{search_type_desc} - {common.get_local_string(30405)}'
     index = ui.show_dlg_select(title, list(dict_languages.values()))
     if index == -1:  # Cancelled
         return None
     lang_code = list(dict_languages.keys())[index]
     lang_desc = list(dict_languages.values())[index]
     # In this case the 'value' is used only as title for the ListItem and not for the query
-    value = search_type_desc + ': ' + lang_desc
+    value = f'{search_type_desc}: {lang_desc}'
     row_id = G.LOCAL_DB.insert_search_item(search_type, value, {'lang_code': lang_code})
     return row_id
 
@@ -219,7 +219,7 @@ def search_query(row_id, perpetual_range_start, dir_update_listing):
 
 @custom_viewmode(G.VIEW_SHOW)
 def _search_results_directory(search_value, menu_data, dir_items, extra_data, dir_update_listing):
-    extra_data['title'] = common.get_local_string(30400) + ' - ' + search_value
+    extra_data['title'] = f'{common.get_local_string(30400)} - {search_value}'
     finalize_directory(dir_items, menu_data.get('content_type', G.CONTENT_SHOW),
                        title=get_title(menu_data, extra_data))
     end_of_directory(dir_update_listing)

--- a/resources/lib/navigation/directory_utils.py
+++ b/resources/lib/navigation/directory_utils.py
@@ -30,7 +30,7 @@ def custom_viewmode(content_type):
             if (G.ADDON.getSettingBool('customview')
                     and f'plugin://{G.ADDON_ID}' in xbmc.getInfoLabel('Container.FolderPath')):
                 # Activate the given skin viewtype if the plugin is run in the foreground
-                view_id = G.ADDON.getSettingInt('viewmode' + _content_type + 'id')
+                view_id = G.ADDON.getSettingInt(f'viewmode{_content_type}id')
                 if view_id > 0:
                     xbmc.executebuiltin(f'Container.SetViewMode({view_id})')
         return set_custom_viewmode

--- a/resources/lib/navigation/directory_utils.py
+++ b/resources/lib/navigation/directory_utils.py
@@ -28,11 +28,11 @@ def custom_viewmode(content_type):
             override_content_type = func(*args, **kwargs)
             _content_type = override_content_type if override_content_type else content_type
             if (G.ADDON.getSettingBool('customview')
-                    and 'plugin://{}'.format(G.ADDON_ID) in xbmc.getInfoLabel('Container.FolderPath')):
+                    and f'plugin://{G.ADDON_ID}' in xbmc.getInfoLabel('Container.FolderPath')):
                 # Activate the given skin viewtype if the plugin is run in the foreground
                 view_id = G.ADDON.getSettingInt('viewmode' + _content_type + 'id')
                 if view_id > 0:
-                    xbmc.executebuiltin('Container.SetViewMode({})'.format(view_id))
+                    xbmc.executebuiltin(f'Container.SetViewMode({view_id})')
         return set_custom_viewmode
     return decorate_viewmode
 

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -107,7 +107,7 @@ def get_inputstream_listitem(videoid):
         raise Exception(common.get_local_string(30046))
     list_item.setProperty(
         key='inputstream.adaptive.stream_headers',
-        value='user-agent=' + common.get_user_agent())
+        value=f'user-agent={common.get_user_agent()}')
     list_item.setProperty(
         key='inputstream.adaptive.license_type',
         value='com.widevine.alpha')

--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -88,7 +88,7 @@ def _play(videoid, is_played_from_strm=False):
 
 def get_inputstream_listitem(videoid):
     """Return a listitem that has all inputstream relevant properties set for playback of the given video_id"""
-    service_url = 'http://127.0.0.1:{}'.format(G.LOCAL_DB.get_value('nf_server_service_port'))
+    service_url = f'http://127.0.0.1:{G.LOCAL_DB.get_value("nf_server_service_port")}'
     manifest_path = MANIFEST_PATH_FORMAT.format(videoid.value)
     list_item = xbmcgui.ListItem(path=service_url + manifest_path, offscreen=True)
     list_item.setContentLookup(False)

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -35,8 +35,8 @@ def catch_exceptions_decorator(func):
             from resources.lib.kodi.ui import show_ok_dialog
             show_ok_dialog('InputStream Helper Add-on error',
                            ('The operation has been cancelled.[CR]'
-                            'InputStream Helper has generated an internal error:[CR]{}[CR][CR]'
-                            'Please report it to InputStream Helper github.'.format(exc)))
+                            f'InputStream Helper has generated an internal error:[CR]{exc}[CR][CR]'
+                            'Please report it to InputStream Helper github.'))
         except HttpError401 as exc:
             # This is a generic error, can happen when the http request for some reason has failed.
             # Known causes:
@@ -46,7 +46,7 @@ def catch_exceptions_decorator(func):
             show_ok_dialog(get_local_string(30105),
                            ('There was a communication problem with Netflix.[CR]'
                             'You can try the operation again or exit.[CR]'
-                            '(Error code: {})').format(exc.__class__.__name__))
+                            f'(Error code: {exc.__class__.__name__})'))
         except (MbrStatusNeverMemberError, MbrStatusFormerMemberError):
             from resources.lib.kodi.ui import show_error_info
             show_error_info(get_local_string(30008), get_local_string(30180), False, True)
@@ -141,7 +141,7 @@ def _get_nav_handler(root_handler, pathitems):
         from resources.lib.navigation.keymaps import KeymapsActionExecutor
         nav_handler = KeymapsActionExecutor
     else:
-        raise InvalidPathError('No root handler for path {}'.format('/'.join(pathitems)))
+        raise InvalidPathError(f'No root handler for path {"/".join(pathitems)}')
     return nav_handler
 
 
@@ -150,7 +150,7 @@ def _execute(executor_type, pathitems, params, root_handler):
     try:
         executor = executor_type(params).__getattribute__(pathitems[0] if pathitems else 'root')
     except AttributeError as exc:
-        raise InvalidPathError('Unknown action {}'.format('/'.join(pathitems))) from exc
+        raise InvalidPathError(f'Unknown action {"/".join(pathitems)}') from exc
     LOG.debug('Invoking action: {}', executor.__name__)
     executor(pathitems=pathitems)
     if root_handler == G.MODE_DIRECTORY and not G.IS_ADDON_EXTERNAL_CALL:
@@ -215,8 +215,8 @@ def run(argv):
     # PR: https://github.com/xbmc/xbmc/pull/13814
     G.init_globals(argv)
 
-    LOG.info('Started (Version {})'.format(G.VERSION_RAW))
-    LOG.info('URL is {}'.format(G.URL))
+    LOG.info('Started (Version {})', G.VERSION_RAW)
+    LOG.info('URL is {}', G.URL)
     success = True
 
     is_external_call = _check_addon_external_call()

--- a/resources/lib/run_service.py
+++ b/resources/lib/run_service.py
@@ -38,11 +38,11 @@ class NetflixService:
             LOG.error(traceback.format_exc())
             if isinstance(exc, gaierror):
                 message = ('Something is wrong in your network localhost configuration.\r\n'
-                           'It is possible that the hostname {} can not be resolved.').format(self.HOST_ADDRESS)
+                           f'It is possible that the hostname {self.HOST_ADDRESS} can not be resolved.')
             elif isinstance(exc, ImportError):
                 message = ('In your system is missing some required library to run Netflix.\r\n'
                            'Read how to install the add-on in the GitHub Readme.\r\n'
-                           'Error details: {}'.format(exc))
+                           f'Error details: {exc}')
             else:
                 message = str(exc)
             self._set_service_status('error', message)
@@ -54,7 +54,7 @@ class NetflixService:
 
         self.nf_server_instance.server_activate()
         self.nf_server_thread.start()
-        LOG.info('[{}] Thread started'.format('NF_SERVER'))
+        LOG.info('[NF_SERVER] Thread started')
 
         self.library_updater = LibraryUpdateService()
         # We reset the value in case of any eventuality (add-on disabled, update, etc)

--- a/resources/lib/services/http_server.py
+++ b/resources/lib/services/http_server.py
@@ -94,7 +94,7 @@ def handle_request(server, handler, func_name, data):
         try:
             func = handler.http_ipc_slots[func_name]
         except KeyError as exc:
-            raise SlotNotImplemented('The specified IPC slot {} does not exist'.format(func_name)) from exc
+            raise SlotNotImplemented(f'The specified IPC slot {func_name} does not exist') from exc
         ret_data = _call_func(func, pickle.loads(data))
     except Exception as exc:  # pylint: disable=broad-except
         if not isinstance(exc, (CacheMiss, MetadataNotAvailable)):
@@ -129,10 +129,10 @@ def handle_request_test(server, handler, func_name, data):
         try:
             func = handler.http_ipc_slots[func_name]
         except KeyError as exc:
-            raise SlotNotImplemented('The specified IPC slot {} does not exist'.format(func_name)) from exc
+            raise SlotNotImplemented(f'The specified IPC slot {func_name} does not exist') from exc
         ret_data = _call_func(func, json.loads(data))
     except Exception as exc:  # pylint: disable=broad-except
-        ret_data = 'The request has failed, error: {}'.format(exc)
+        ret_data = f'The request has failed, error: {exc}'
     if ret_data:
         server.wfile.write(json.dumps(ret_data).encode('utf-8'))
 
@@ -141,7 +141,7 @@ def _call_instance_func(instance, func_name, data):
     try:
         func = getattr(instance, func_name)
     except AttributeError as exc:
-        raise InvalidPathError('Function {} not found'.format(func_name)) from exc
+        raise InvalidPathError(f'Function {func_name} not found') from exc
     if isinstance(data, dict):
         return func(**data)
     if data is not None:

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -89,7 +89,7 @@ def _create_profile_item(profile_guid, is_selected, is_autoselect, is_library_pl
     profile_name = G.LOCAL_DB.get_profile_config('profileName', '???', guid=profile_guid)
     profile_attributes = []
     if G.LOCAL_DB.get_profile_config('isPinLocked', False, guid=profile_guid):
-        profile_attributes.append('[COLOR red]' + common.get_local_string(20068) + '[/COLOR]')
+        profile_attributes.append(f'[COLOR red]{common.get_local_string(20068)}[/COLOR]')
     if G.LOCAL_DB.get_profile_config('isAccountOwner', False, guid=profile_guid):
         profile_attributes.append(common.get_local_string(30221))
     if G.LOCAL_DB.get_profile_config('isKids', False, guid=profile_guid):
@@ -99,7 +99,7 @@ def _create_profile_item(profile_guid, is_selected, is_autoselect, is_library_pl
     if is_library_playback and detailed_info:
         profile_attributes.append(common.get_local_string(30051))
     attributes_desc = '[CR]'.join(profile_attributes) + '[CR]' if profile_attributes else ''
-    description = attributes_desc + '[' + G.LOCAL_DB.get_profile_config('language_desc', '', guid=profile_guid) + ']'
+    description = f'{attributes_desc}[{G.LOCAL_DB.get_profile_config("language_desc", "", guid=profile_guid)}]'
 
     if detailed_info:
         menu_items = generate_context_menu_profile(profile_guid, is_autoselect, is_library_playback)
@@ -131,7 +131,7 @@ def build_season_listing(season_list, tvshowid, pathitems=None):
     # add_items_previous_next_page use the new value of perpetual_range_selector
     add_items_previous_next_page(directory_items, pathitems, season_list.perpetual_range_selector, tvshowid)
     G.CACHE_MANAGEMENT.execute_pending_db_ops()
-    return directory_items, {'title': season_list.tvshow['title'] + ' - ' + common.get_local_string(20366)[2:]}
+    return directory_items, {'title': f'{season_list.tvshow["title"]} - {common.get_local_string(20366)[2:]}'}
 
 
 def _create_season_item(tvshowid, seasonid_value, season, season_list, common_data):
@@ -160,7 +160,7 @@ def build_episode_listing(episodes_list, seasonid, pathitems=None):
     # add_items_previous_next_page use the new value of perpetual_range_selector
     add_items_previous_next_page(directory_items, pathitems, episodes_list.perpetual_range_selector)
     G.CACHE_MANAGEMENT.execute_pending_db_ops()
-    return directory_items, {'title': episodes_list.tvshow['title'] + ' - ' + episodes_list.season['summary']['name']}
+    return directory_items, {'title': f'{episodes_list.tvshow["title"]} - {episodes_list.season["summary"]["name"]}'}
 
 
 def _create_episode_item(seasonid, episodeid_value, episode, episodes_list, common_data):
@@ -269,7 +269,7 @@ def build_video_listing(video_list, menu_data, sub_genre_id=None, pathitems=None
     # If genre_id exists add possibility to browse LoCo sub-genres
     if sub_genre_id and sub_genre_id != 'None':
         # Create dynamic sub-menu info in MAIN_MENU_ITEMS
-        menu_id = 'subgenre_' + sub_genre_id
+        menu_id = f'subgenre_{sub_genre_id}'
         sub_menu_data = menu_data.copy()
         sub_menu_data['path'] = [menu_data['path'][0], menu_id, sub_genre_id]
         sub_menu_data['loco_known'] = False
@@ -322,7 +322,7 @@ def _create_video_item(videoid_value, video, video_list, perpetual_range_start, 
         try:
             #  Due to the add-on cache we can not change in easy way the value stored in database cache,
             #  then we temporary override the value (see 'remind_me' in navigation/actions.py)
-            is_in_remind_me = G.CACHE.get(CACHE_BOOKMARKS, 'is_in_remind_me_' + str(videoid))
+            is_in_remind_me = G.CACHE.get(CACHE_BOOKMARKS, f'is_in_remind_me_{videoid}')
         except CacheMiss:
             #  The website check the "Remind Me" value on key "inRemindMeList" and also "queue"/"inQueue"
             is_in_remind_me = video['inRemindMeList'] or video['queue']['inQueue']

--- a/resources/lib/services/nfsession/directorybuilder/dir_path_requests.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_path_requests.py
@@ -88,7 +88,7 @@ class DirectoryPathRequests:
         try:
             return next(iter(self.req_loco_list_root().lists_by_context([context], True)))[0]
         except StopIteration as exc:
-            raise InvalidVideoListTypeError('No lists with context {} available'.format(context)) from exc
+            raise InvalidVideoListTypeError(f'No lists with context {context} available') from exc
 
     @cache_utils.cache_output(cache_utils.CACHE_COMMON, fixed_identifier='profiles_raw_data',
                               ttl=300, ignore_self_class=True)
@@ -109,7 +109,7 @@ class DirectoryPathRequests:
     def req_seasons(self, videoid, perpetual_range_start):
         """Retrieve the seasons of a tv show"""
         if videoid.mediatype != common.VideoId.SHOW:
-            raise InvalidVideoId('Cannot request season list for {}'.format(videoid))
+            raise InvalidVideoId(f'Cannot request season list for {videoid}')
         LOG.debug('Requesting the seasons list for show {}', videoid)
         call_args = {
             'paths': (build_paths(['videos', videoid.tvshowid], SEASONS_PARTIAL_PATHS) +
@@ -125,7 +125,7 @@ class DirectoryPathRequests:
     def req_episodes(self, videoid, perpetual_range_start=None):
         """Retrieve the episodes of a season"""
         if videoid.mediatype != common.VideoId.SEASON:
-            raise InvalidVideoId('Cannot request episode list for {}'.format(videoid))
+            raise InvalidVideoId(f'Cannot request episode list for {videoid}')
         LOG.debug('Requesting episode list for {}', videoid)
         paths = ([['seasons', videoid.seasonid, 'summary']] +
                  build_paths(['seasons', videoid.seasonid, 'episodes', RANGE_PLACEHOLDER], EPISODES_PARTIAL_PATHS) +
@@ -184,7 +184,7 @@ class DirectoryPathRequests:
     def req_video_list_supplemental(self, videoid, supplemental_type):
         """Retrieve a video list of supplemental type videos"""
         if videoid.mediatype != common.VideoId.SHOW and videoid.mediatype != common.VideoId.MOVIE:
-            raise InvalidVideoId('Cannot request video list supplemental for {}'.format(videoid))
+            raise InvalidVideoId(f'Cannot request video list supplemental for {videoid}')
         LOG.debug('Requesting video list supplemental of type "{}" for {}', supplemental_type, videoid)
         path = build_paths(
             ['videos', videoid.value, supplemental_type, {"from": 0, "to": 35}], TRAILER_PARTIAL_PATHS
@@ -268,7 +268,7 @@ class DirectoryPathRequests:
                               identify_append_from_kwarg_name='category_name', ignore_self_class=True)
     def req_lolomo_category(self, category_name):
         """Retrieve LoLoMo by category lists"""
-        LOG.debug('Requesting LoLoMo "{}" category lists'.format(category_name))
+        LOG.debug('Requesting LoLoMo "{}" category lists', category_name)
         paths = ([['lolomoByCategory', category_name, ['componentSummary']],
                   ['lolomoByCategory', category_name, {'from': 0, 'to': 10}, ['componentSummary']],
                   # Titles of first 4 videos in each video list (needed only to show titles in the plot description)

--- a/resources/lib/services/nfsession/directorybuilder/dir_path_requests.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_path_requests.py
@@ -213,7 +213,7 @@ class DirectoryPathRequests:
     def req_video_list_search(self, search_term, perpetual_range_start=None):
         """Retrieve a video list by search term"""
         LOG.debug('Requesting video list by search term "{}"', search_term)
-        base_path = ['search', 'byTerm', '|' + search_term, 'titles', PATH_REQUEST_SIZE_STD]
+        base_path = ['search', 'byTerm', f'|{search_term}', 'titles', PATH_REQUEST_SIZE_STD]
         paths = ([base_path + [['id', 'name', 'requestId']]] +
                  build_paths(base_path + [RANGE_PLACEHOLDER, 'reference'], VIDEO_LIST_PARTIAL_PATHS))
         call_args = {

--- a/resources/lib/services/nfsession/msl/android_crypto.py
+++ b/resources/lib/services/nfsession/msl/android_crypto.py
@@ -67,7 +67,7 @@ class AndroidMSLCrypto(MSLBaseCrypto):
                                                 WidevineForceSecLev.DISABLED,
                                                 table=TABLE_SESSION)
         if wv_force_sec_lev != WidevineForceSecLev.DISABLED:
-            LOG.warn('Widevine security level is forced to {} by user settings!'.format(wv_force_sec_lev))
+            LOG.warn('Widevine security level is forced to {} by user settings!', wv_force_sec_lev)
         LOG.debug('Widevine CryptoSession current hdcp level: {}', drm_info['hdcp_level'])
         LOG.debug('Widevine CryptoSession max hdcp level supported: {}', drm_info['hdcp_level_max'])
         LOG.debug('Widevine CryptoSession algorithms: {}', self.crypto_session.GetPropertyString('algorithms'))

--- a/resources/lib/services/nfsession/msl/converter.py
+++ b/resources/lib/services/nfsession/msl/converter.py
@@ -75,7 +75,7 @@ def _add_segment_base(representation, init_length):
     ET.SubElement(
         representation,  # Parent
         'SegmentBase',  # Tag
-        indexRange='0-' + str(init_length),
+        indexRange=f'0-{init_length}',
         indexRangeExact='true')
 
 
@@ -189,7 +189,7 @@ def _determine_video_codec(content_profile):
             return 'dvhe'
         return 'hevc'
     if content_profile.startswith('vp9'):
-        return 'vp9.' + content_profile[11:12]
+        return f'vp9.{content_profile[11:12]}'
     return 'h264'
 
 

--- a/resources/lib/services/nfsession/msl/events_handler.py
+++ b/resources/lib/services/nfsession/msl/events_handler.py
@@ -81,7 +81,7 @@ class EventsHandler(threading.Thread):
         # Request attempts can be made up to a maximum of 3 times per event
         LOG.info('EVENT [{}] - Executing request', event_type)
         endpoint_url = ENDPOINTS['events'] + create_req_params(20 if event_type == EVENT_START else 0,
-                                                               'events/{}'.format(event_type))
+                                                               f'events/{event_type}')
         try:
             response = self.chunked_request(endpoint_url, request_data, get_esn(),
                                             disable_msl_switch=False)

--- a/resources/lib/services/nfsession/msl/msl_handler.py
+++ b/resources/lib/services/nfsession/msl/msl_handler.py
@@ -142,7 +142,7 @@ class MSLHandler:
 
     @measure_exec_time_decorator(is_immediate=True)
     def _get_manifest(self, viewable_id, esn):
-        cache_identifier = esn + '_' + str(viewable_id)
+        cache_identifier = f'{esn}_{viewable_id}'
         try:
             # The manifest must be requested once and maintained for its entire duration
             manifest = G.CACHE.get(CACHE_MANIFESTS, cache_identifier)

--- a/resources/lib/services/nfsession/msl/msl_requests.py
+++ b/resources/lib/services/nfsession/msl/msl_requests.py
@@ -174,7 +174,7 @@ class MSLRequests(MSLRequestBuilder):
         while True:
             try:
                 if is_attempts_enabled:
-                    _endpoint = endpoint.replace('reqAttempt=', 'reqAttempt=' + str(retry))
+                    _endpoint = endpoint.replace('reqAttempt=', f'reqAttempt={retry}')
                 else:
                     _endpoint = endpoint
                 LOG.debug('Executing POST request to {}', _endpoint)
@@ -221,8 +221,9 @@ class MSLRequests(MSLRequestBuilder):
 
 def _process_json_response(response):
     """Processes the response data by returning header and payloads in JSON format and check for possible MSL error"""
+    comma_separated_response = response.replace('}{', '},{')
     try:
-        data = json.loads('[' + response.replace('}{', '},{') + ']')
+        data = json.loads(f'[{comma_separated_response}]')
         # On 'data' list the first dict is always the header or the error
         payloads = [msg_part for msg_part in data if 'payload' in msg_part]
         return _raise_if_error(data[0]), payloads

--- a/resources/lib/services/nfsession/msl/msl_utils.py
+++ b/resources/lib/services/nfsession/msl/msl_utils.py
@@ -124,8 +124,9 @@ def _find_audio_data(player_state, manifest):
             stream = max(audio_track['streams'], key=lambda x: x['bitrate'])
             return stream['downloadable_id'], audio_track['new_track_id']
     # Not found?
-    raise Exception('build_media_tag: unable to find audio data with language: {}, channels: {}'
-                    .format(language, channels))
+    raise Exception(
+        f'build_media_tag: unable to find audio data with language: {language}, channels: {channels}'
+    )
 
 
 def _find_video_data(player_state, manifest):
@@ -140,8 +141,9 @@ def _find_video_data(player_state, manifest):
             if codec in stream['content_profile'] and width == stream['res_w'] and height == stream['res_h']:
                 return stream['downloadable_id'], video_track['new_track_id']
     # Not found?
-    raise Exception('build_media_tag: unable to find video data with codec: {}, width: {}, height: {}'
-                    .format(codec, width, height))
+    raise Exception(
+        f'build_media_tag: unable to find video data with codec: {codec}, width: {width}, height: {height}'
+    )
 
 
 def generate_logblobs_params():

--- a/resources/lib/services/nfsession/msl/msl_utils.py
+++ b/resources/lib/services/nfsession/msl/msl_utils.py
@@ -54,7 +54,7 @@ def display_error_info(func):
         try:
             return func(*args, **kwargs)
         except Exception as exc:
-            message = exc.__class__.__name__ + ': ' + str(exc)
+            message = f'{exc.__class__.__name__}: {exc}'
             ui.show_error_info(common.get_local_string(30028), message,
                                unknown_error=not message,
                                netflix_error=isinstance(exc, MSLError))
@@ -150,7 +150,7 @@ def generate_logblobs_params():
     """Generate the initial log blog"""
     # It seems that this log is sent when logging in to a profile the first time
     # i think it is the easiest to reproduce, the others contain too much data
-    screen_size = str(xbmcgui.getScreenWidth()) + 'x' + str(xbmcgui.getScreenHeight())
+    screen_size = f'{xbmcgui.getScreenWidth()}x{xbmcgui.getScreenHeight()}'
     timestamp_utc = time.time()
     timestamp = int(timestamp_utc * 1000)
     app_id = int(time.time()) * 10000 + random.SystemRandom().randint(1, 10001)  # Should be used with all log requests
@@ -220,4 +220,4 @@ def create_req_params(req_priority, req_name):
         ('osname', G.LOCAL_DB.get_value('browser_info_os_name', '', table=TABLE_SESSION).lower()),
         ('osversion', G.LOCAL_DB.get_value('browser_info_os_version', '', table=TABLE_SESSION))
     ]
-    return '?' + urlencode(params)
+    return f'?{urlencode(params)}'

--- a/resources/lib/services/nfsession/nfsession_ops.py
+++ b/resources/lib/services/nfsession/nfsession_ops.py
@@ -255,7 +255,7 @@ class NFSessionOperations(SessionPathRequests):
         # by checking if the red status bar of watched time position appears and will be updated, or also
         # if continueWatching list will be updated (e.g. try to play a new tvshow not contained in the "my list")
         call_paths = [['refreshVideoCurrentPositions']]
-        params = ['[' + video_id + ']', '[]']
+        params = [f'[{video_id}]', '[]']
         try:
             response = self.callpath_request(call_paths, params)
             LOG.debug('refreshVideoCurrentPositions response: {}', response)

--- a/resources/lib/services/nfsession/session/http_requests.py
+++ b/resources/lib/services/nfsession/session/http_requests.py
@@ -178,8 +178,8 @@ class SessionHTTPRequests(SessionBase):
             # Special case used by path_request/callpath_request in path_requests.py
             data_converted = data
             if endpoint_conf['add_auth_url'] == 'to_data':
-                auth_data = 'authURL=' + self.auth_url
-                data_converted += '&' + auth_data if data_converted else auth_data
+                auth_data = f'authURL={self.auth_url}'
+                data_converted += f'&{auth_data}' if data_converted else auth_data
         return data_converted, headers, params
 
 

--- a/resources/lib/services/nfsession/session/http_requests.py
+++ b/resources/lib/services/nfsession/session/http_requests.py
@@ -190,10 +190,8 @@ def _document_url(endpoint_address, kwargs):
 
 
 def _api_url(endpoint_address):
-    return '{baseurl}{endpoint_adr}'.format(
-        baseurl=G.LOCAL_DB.get_value('api_endpoint_url', table=TABLE_SESSION),
-        endpoint_adr=endpoint_address)
-
+    baseurl = G.LOCAL_DB.get_value('api_endpoint_url', table=TABLE_SESSION)
+    return f'{baseurl}{endpoint_address}'
 
 def _raise_api_error(decoded_response):
     if decoded_response.get('status', 'success') == 'error':

--- a/resources/lib/services/playback/action_controller.py
+++ b/resources/lib/services/playback/action_controller.py
@@ -248,7 +248,7 @@ def _notify_managers(manager, notification, data):
             notify_method()
     except Exception as exc:  # pylint: disable=broad-except
         manager.enabled = False
-        msg = '{} disabled due to exception: {}'.format(manager.name, exc)
+        msg = f'{manager.name} disabled due to exception: {exc}'
         import traceback
         LOG.error(traceback.format_exc())
         ui.show_notification(title=common.get_local_string(30105), msg=msg)

--- a/resources/lib/services/playback/am_playback.py
+++ b/resources/lib/services/playback/am_playback.py
@@ -33,7 +33,7 @@ class AMPlayback(ActionManager):
         self.watched_threshold = None
 
     def __str__(self):
-        return 'enabled={}'.format(self.enabled)
+        return f'enabled={self.enabled}'
 
     def initialize(self, data):
         self.resume_position = data.get('resume_position')

--- a/resources/lib/services/playback/am_section_skipping.py
+++ b/resources/lib/services/playback/am_section_skipping.py
@@ -31,9 +31,7 @@ class AMSectionSkipper(ActionManager):
         self.pause_on_skip = False
 
     def __str__(self):
-        return ('enabled={}, markers={}, auto_skip={}, pause_on_skip={}'
-                .format(self.enabled, self.markers, self.auto_skip,
-                        self.pause_on_skip))
+        return f'enabled={self.enabled}, markers={self.markers}, auto_skip={self.auto_skip}, pause_on_skip={self.pause_on_skip}'
 
     def initialize(self, data):
         self.markers = get_timeline_markers(data['metadata'][0])

--- a/resources/lib/services/playback/am_stream_continuity.py
+++ b/resources/lib/services/playback/am_stream_continuity.py
@@ -61,8 +61,7 @@ class AMStreamContinuity(ActionManager):
         self.is_prefer_alternative_lang = None
 
     def __str__(self):
-        return ('enabled={}, videoid_parent={}'
-                .format(self.enabled, self.videoid_parent))
+        return f'enabled={self.enabled}, videoid_parent={self.videoid_parent}'
 
     def initialize(self, data):
         self.is_kodi_forced_subtitles_only = common.get_kodi_subtitle_language() == 'forced_only'

--- a/resources/lib/services/playback/am_upnext_notifier.py
+++ b/resources/lib/services/playback/am_upnext_notifier.py
@@ -36,7 +36,7 @@ class AMUpNextNotifier(ActionManager):
         self.upnext_info = None
 
     def __str__(self):
-        return 'enabled={}'.format(self.enabled)
+        return f'enabled={self.enabled}'
 
     def initialize(self, data):
         if not xbmc.getCondVisibility('System.AddonIsEnabled(service.upnext)'):

--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -45,7 +45,7 @@ class AMVideoEvents(ActionManager):
         self.allow_request_update_loco = False
 
     def __str__(self):
-        return 'enabled={}'.format(self.enabled)
+        return f'enabled={self.enabled}'
 
     def initialize(self, data):
         if self.videoid.mediatype not in [common.VideoId.MOVIE, common.VideoId.EPISODE]:

--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -202,5 +202,5 @@ class AMVideoEvents(ActionManager):
 
 def _get_manifest(videoid):
     """Get the manifest from cache"""
-    cache_identifier = get_esn() + '_' + videoid.value
+    cache_identifier = f'{get_esn()}_{videoid.value}'
     return G.CACHE.get(CACHE_MANIFESTS, cache_identifier)

--- a/resources/lib/services/settings_monitor.py
+++ b/resources/lib/services/settings_monitor.py
@@ -39,7 +39,7 @@ class SettingsMonitor(xbmc.Monitor):
         # This method will be called when user change add-on settings or every time ADDON.setSetting...() is called
         if self.ignore_n_events > 0:
             self.ignore_n_events -= 1
-            LOG.debug('SettingsMonitor: onSettingsChanged event ignored (remaining {})'.format(self.ignore_n_events))
+            LOG.debug('SettingsMonitor: onSettingsChanged event ignored (remaining {})', self.ignore_n_events)
             return
         try:
             self._on_change()
@@ -82,22 +82,22 @@ class SettingsMonitor(xbmc.Monitor):
             # Check settings changes in show/hide menu
             if menu_data.get('has_show_setting', True):
                 show_menu_new_setting = bool(G.ADDON.getSettingBool('_'.join(('show_menu', menu_id))))
-                show_menu_old_setting = G.LOCAL_DB.get_value('menu_{}_show'.format(menu_id),
+                show_menu_old_setting = G.LOCAL_DB.get_value(f'menu_{menu_id}_show',
                                                              True,
                                                              TABLE_SETTINGS_MONITOR)
                 if show_menu_new_setting != show_menu_old_setting:
-                    G.LOCAL_DB.set_value('menu_{}_show'.format(menu_id),
+                    G.LOCAL_DB.set_value(f'menu_{menu_id}_show',
                                          show_menu_new_setting,
                                          TABLE_SETTINGS_MONITOR)
                     reboot_addon = True
             # Check settings changes in sort order of menu
             if menu_data.get('has_sort_setting'):
                 menu_sortorder_new_setting = int(G.ADDON.getSettingInt('menu_sortorder_' + menu_data['path'][1]))
-                menu_sortorder_old_setting = G.LOCAL_DB.get_value('menu_{}_sortorder'.format(menu_id),
+                menu_sortorder_old_setting = G.LOCAL_DB.get_value(f'menu_{menu_id}_sortorder',
                                                                   0,
                                                                   TABLE_SETTINGS_MONITOR)
                 if menu_sortorder_new_setting != menu_sortorder_old_setting:
-                    G.LOCAL_DB.set_value('menu_{}_sortorder'.format(menu_id),
+                    G.LOCAL_DB.set_value(f'menu_{menu_id}_sortorder',
                                          menu_sortorder_new_setting,
                                          TABLE_SETTINGS_MONITOR)
                     clean_buckets += [CACHE_COMMON, CACHE_MYLIST, CACHE_SEARCH]

--- a/resources/lib/upgrade_actions.py
+++ b/resources/lib/upgrade_actions.py
@@ -44,7 +44,7 @@ def migrate_library():
                                max_value=len(folders)) as progress_bar:
             for folder_path in folders:
                 folder_name = os.path.basename(xbmcvfs.translatePath(folder_path))
-                progress_bar.set_message('PLEASE WAIT - Migrating: ' + folder_name)
+                progress_bar.set_message(f'PLEASE WAIT - Migrating: {folder_name}')
                 _migrate_strm_files(folder_path)
     except Exception as exc:  # pylint: disable=broad-except
         LOG.error('Migrating failed: {}', exc)

--- a/resources/lib/utils/api_paths.py
+++ b/resources/lib/utils/api_paths.py
@@ -254,7 +254,8 @@ def reference_path(ref):
     if isinstance(ref, dict):
         return ref['value'] if ref.get('$type') == 'ref' else None
     raise InvalidReferenceError(
-        'Unexpected reference format encountered: {}'.format(ref))
+        f'Unexpected reference format encountered: {ref}'
+    )
 
 
 def _remove_nesting(ref):

--- a/resources/lib/utils/api_requests.py
+++ b/resources/lib/utils/api_requests.py
@@ -129,7 +129,7 @@ def _update_mylist_cache(videoid, operation, params):
     perpetual_range_start = params.get('perpetual_range_start')
     mylist_identifier = 'mylist'
     if perpetual_range_start and perpetual_range_start != 'None':
-        mylist_identifier += '_' + perpetual_range_start
+        mylist_identifier += f'_{perpetual_range_start}'
     if operation == 'remove':
         try:
             video_list_sorted_data = G.CACHE.get(cache_utils.CACHE_MYLIST, mylist_identifier)

--- a/resources/lib/utils/cookies.py
+++ b/resources/lib/utils/cookies.py
@@ -70,9 +70,7 @@ def log_cookie(cookie_jar):
     debug_output = 'Cookies currently loaded:\n'
     for cookie in cookie_jar:
         remaining_ttl = int((cookie.expires or 0) - time()) if cookie.expires else None
-        debug_output += '{} (expires ts {} - remaining TTL {} sec)\n'.format(cookie.name,
-                                                                             cookie.expires,
-                                                                             remaining_ttl)
+        debug_output += f'{cookie.name} (expires ts {cookie.expires} - remaining TTL {remaining_ttl} sec)\n'
     LOG.debug(debug_output)
 
 

--- a/resources/lib/utils/esn.py
+++ b/resources/lib/utils/esn.py
@@ -128,7 +128,7 @@ def generate_android_esn(wv_force_sec_lev=None):
                 esn += model[:45].replace(' ', '=')
                 esn = sub(r'[^A-Za-z0-9=-]', '=', esn)
                 if system_id:
-                    esn += '-' + system_id + '-'
+                    esn += f'-{system_id}-'
                 LOG.debug('Generated Android ESN: {} (widevine force sec.lev. set as "{}")', esn, wv_force_sec_lev)
                 return esn
         except OSError:

--- a/resources/lib/utils/logging.py
+++ b/resources/lib/utils/logging.py
@@ -33,7 +33,7 @@ class Logging:
             return
         self.__addon_id = addon_id
         self.__plugin_handle = plugin_handle
-        self.__log('The debug logging is set as {}'.format('ENABLED' if is_enabled else 'DISABLED'), xbmc.LOGINFO)
+        self.__log(f'The debug logging is set as {"ENABLED" if is_enabled else "DISABLED"}', xbmc.LOGINFO)
         self.is_enabled = is_enabled
         self.is_time_trace_enabled = is_enabled and is_time_trace_enabled
         if is_enabled:
@@ -115,7 +115,7 @@ def logdetails_decorator(func):
         """Wrapper function to maintain correct stack traces"""
         that = args[0]
         class_name = that.__class__.__name__
-        arguments = [':{} = {}:'.format(key, value)
+        arguments = [f':{key} = {value}:'
                      for key, value in kwargs.items()
                      if key not in ['account', 'credentials']]
         if arguments:

--- a/resources/lib/utils/website.py
+++ b/resources/lib/utils/website.py
@@ -246,12 +246,12 @@ def validate_login(react_context):
             error_code = common.get_path(path_error_code, react_context)
             LOG.error('Login not valid, error code {}', error_code)
             error_description = common.get_local_string(30102) + error_code
-            if error_code in error_code_list:
-                error_description = error_code_list[error_code]
-            if 'email_' + error_code in error_code_list:
-                error_description = error_code_list['email_' + error_code]
             if 'login_' + error_code in error_code_list:
                 error_description = error_code_list['login_' + error_code]
+            elif 'email_' + error_code in error_code_list:
+                error_description = error_code_list['email_' + error_code]
+            elif error_code in error_code_list:
+                error_description = error_code_list[error_code]
             raise LoginValidateError(common.remove_html_tags(error_description))
         except (AttributeError, KeyError) as exc:
             import traceback

--- a/resources/lib/utils/website.py
+++ b/resources/lib/utils/website.py
@@ -285,7 +285,7 @@ def extract_json(content, name):
             LOG.error('JSON string trying to load: {}', json_str)
         import traceback
         LOG.error(traceback.format_exc())
-        raise WebsiteParsingError('Unable to extract {}'.format(name)) from exc
+        raise WebsiteParsingError(f'Unable to extract {name}') from exc
 
 
 def extract_parental_control_data(content, current_maturity):

--- a/resources/lib/utils/website.py
+++ b/resources/lib/utils/website.py
@@ -246,10 +246,10 @@ def validate_login(react_context):
             error_code = common.get_path(path_error_code, react_context)
             LOG.error('Login not valid, error code {}', error_code)
             error_description = common.get_local_string(30102) + error_code
-            if 'login_' + error_code in error_code_list:
-                error_description = error_code_list['login_' + error_code]
-            elif 'email_' + error_code in error_code_list:
-                error_description = error_code_list['email_' + error_code]
+            if f'login_{error_code}' in error_code_list:
+                error_description = error_code_list[f'login_{error_code}']
+            elif f'email_{error_code}' in error_code_list:
+                error_description = error_code_list[f'email_{error_code}']
             elif error_code in error_code_list:
                 error_description = error_code_list[error_code]
             raise LoginValidateError(common.remove_html_tags(error_description))

--- a/tests/AddonSignals.py
+++ b/tests/AddonSignals.py
@@ -34,7 +34,7 @@ def _decodeData(data):
 
 
 def _encodeData(data):
-    return '\\"[\\"{0}\\"]\\"'.format(binascii.hexlify(json.dumps(data)))
+    return f'\\"[\\"{binascii.hexlify(json.dumps(data))}\\"]\\"'
 
 
 class SignalReceiver(xbmc.Monitor):
@@ -74,7 +74,7 @@ class CallHandler:
         self._return = None
         self.is_callback_received = False
         self.use_timeout_exception = use_timeout_exception
-        registerSlot(self.sourceID, '_return.{0}'.format(self.signal), self.callback)
+        registerSlot(self.sourceID, f'_return.{self.signal}', self.callback)
         sendSignal(signal, data, self.sourceID)
 
     def callback(self, data):
@@ -111,7 +111,7 @@ def sendSignal(signal, data=None, source_id=None, sourceID=None):
     if sourceID:
         xbmc.log('++++==== script.module.addon.signals: sourceID keyword is DEPRECATED - use source_id ====++++', xbmc.LOGNOTICE)
     source_id = source_id or sourceID or xbmcaddon.Addon().getAddonInfo('id')
-    command = 'XBMC.NotifyAll({0}.SIGNAL,{1},{2})'.format(source_id, signal, _encodeData(data))
+    command = f'XBMC.NotifyAll({source_id}.SIGNAL,{signal},{_encodeData(data)})'
     xbmc.executebuiltin(command)
 
 
@@ -120,7 +120,7 @@ def registerCall(signaler_id, signal, callback):
 
 
 def returnCall(signal, data=None, source_id=None):
-    sendSignal('_return.{0}'.format(signal), data, source_id)
+    sendSignal(f'_return.{signal}', data, source_id)
 
 
 def makeCall(signal, data=None, source_id=None, timeout_ms=1000, use_timeout_exception=False):

--- a/tests/run.py
+++ b/tests/run.py
@@ -21,14 +21,14 @@ if len(sys.argv) > 1:
     path = sys.argv[1].lstrip('/') or default
 else:
     path = default
-uri = 'plugin://plugin.video.netflix/{path}'.format(path=path)
+uri = f'plugin://plugin.video.netflix/{path}'
 sys.argv = [uri, '0', '']
 
 
 from resources.lib import run_addon  # pylint: disable=wrong-import-position
 run_addon.G.init_globals(sys.argv)
-run_addon.LOG.info('Started (Version {})'.format(run_addon.G.VERSION))
-run_addon.LOG.info('URL is {}'.format(run_addon.G.URL))
+run_addon.LOG.info('Started (Version {})', run_addon.G.VERSION)
+run_addon.LOG.info('URL is {}', run_addon.G.URL)
 if run_addon._check_valid_credentials():  # pylint: disable=protected-access
     if run_addon.check_addon_upgrade():
         from resources.lib.config_wizard import run_addon_configuration  # pylint: disable=wrong-import-position


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [ ] I have successfully tested my changes locally (ran the linter and was going to run the others before opening this PR, but then I accidentally pressed the wrong button before running everything. Sorry about that 🙇 )

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->

#### Use f-strings instead of `.format` and string concatenation

I was going to look into a problem regarding profile name not displaying correctly, but when looking at the code base I saw a lot of strings that use the old `.format()` injection of variables instead of `f-strings`. I feel that `f-strings` are (in almost all cases) easier to read than the old (and slower) `.format()` syntax.

```python
# Example 1:
LOG.debug('Registered AddonSignals slot {} to {}'.format(name, callback))
↓
LOG.debug(f'Registered AddonSignals slot {name} to {callback}')


# Example 2:
query = 'SELECT {} FROM {} WHERE {} = ?'.format(table_columns[1],
                                                table_name,
                                                table_columns[0])
↓
query = f'SELECT {table_columns[1]} FROM {table_name} WHERE {table_columns[0]} = ?'
```

I did update almost all places that used `.format()`, but  I did keep it in a few places where I thought that it was easier to read than `f-strings`.

I did also update a lot of string concatenation to be f-strings instead, but did here also keep the string concatenation at a few places where I thought it made sense.

```python
# Example 3:
query = 'SELECT ' + enum_vid_prop + ' FROM video_lib_tvshows WHERE TvShowID = ?'
↓
query = f'SELECT {enum_vid_prop} FROM video_lib_tvshows WHERE TvShowID = ?'


# Example 4:
sets_columns = ['@' + col for col in columns]
↓
sets_columns = [f'@{col}' for col in columns]


# Example 5:
data += '\nDebug enabled: ' + str(LOG.is_enabled)
↓
data += f'\nDebug enabled: {LOG.is_enabled}'
```

I thought that "this can't be too much work, let's just do it", and totally regretted it because it took a lot of time 😆 But I understand if not everyone likes `f-strings` (even though I love them), so totally fine if you want to not accept it due to "not matching coding style". Anyhow, still hope you like it 🤞 

#### Reformat if-statement

https://github.com/CastagnaIT/plugin.video.netflix/pull/1177/commits/97cda96e499aea066645d2fcb7aead7f5c96db6a

#### Grammar in PR-template

(Nothing big, just my auto-correct that found them):
https://github.com/CastagnaIT/plugin.video.netflix/pull/1177/commits/c8f26eb9343394ec870f669b24985a2fb1ddf094