### PR TITLE
Version bump (1.17.0)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.netflix" name="Netflix" version="1.16.2+matrix.1" provider-name="libdev + jojo + asciidisco + caphm + castagnait">
+<addon id="plugin.video.netflix" name="Netflix" version="1.17.0+matrix.1" provider-name="libdev + jojo + asciidisco + caphm + castagnait">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.addon.signals" version="0.0.6+matrix.1"/>
@@ -86,12 +86,9 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=329767</forum>
     <source>https://github.com/CastagnaIT/plugin.video.netflix</source>
     <news>
-v1.16.2 (2021-07-16)
-- Implemented new licensed manifest request (to have HD is mandatory to update InputStream Adaptive to last version)
-- Fixed "This title is not available to watch instantly" error on some ARM devices incorrectly identified
-- Fixed empty lists on menu/submenus due to website changes
-- Update translation zh_cn
-- Minor changes
+v1.17.0 (2021-08-13)
+- Migration to HTTP2 protocol
+- Fixed login with username/password for more than 90% of cases
     </news>
   </extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v1.17.0 (2021-08-13)
+- Migration to HTTP2 protocol
+- Fixed login with username/password for more than 90% of cases
+
 v1.16.2 (2021-07-16)
 - Implemented new licensed manifest request (to have HD is mandatory to update InputStream Adaptive to last version)
 - Fixed "This title is not available to watch instantly" error on some ARM devices incorrectly identified


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
With this new version we will test the transition with HTTP2 on a large scale
i have tested this new version for about 3 months without problems
and from various tests from different users has no reported regressions

the best thing is that this change make working the login with username/password again!

only one user has reported login problem also with this new version,
for now we can say that more than 95% of time the login should works
we will see future reports

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
