### PR TITLE
Changes from website related to sync watched status

### DIFF
--- a/resources/lib/services/nfsession/msl/events_handler.py
+++ b/resources/lib/services/nfsession/msl/events_handler.py
@@ -96,9 +96,9 @@ class EventsHandler(threading.Thread):
                             self.loco_data['list_id'],
                             self.loco_data['list_index'])
                     else:
-                        LOG.warn('EventsHandler: LoCo list not updated due to missing list context data')
-                    video_id = request_data['params']['sessionParams']['uiplaycontext']['video_id']
-                    self.nfsession.update_videoid_bookmark(video_id)
+                        LOG.debug('EventsHandler: LoCo list not updated no list context data provided')
+                    # video_id = request_data['params']['sessionParams']['uiplaycontext']['video_id']
+                    # self.nfsession.update_videoid_bookmark(video_id)
                 self.loco_data = None
         except Exception as exc:  # pylint: disable=broad-except
             LOG.error('EVENT [{}] - The request has failed: {}', event_type, exc)
@@ -150,20 +150,29 @@ class EventsHandler(threading.Thread):
         # else:
         #     list_id = G.LOCAL_DB.get_value('last_menu_id', 'unknown')
 
+        position = player_state['elapsed_seconds']
+        if position != 1:
+            position *= 1000
+
         if msl_utils.is_media_changed(previous_player_state, player_state):
-            play_times, media_id = msl_utils.build_media_tag(player_state, manifest)
+            play_times, video_track_id, audio_track_id, sub_track_id = msl_utils.build_media_tag(player_state, manifest,
+                                                                                                 position)
         else:
             play_times = previous_data['playTimes']
             msl_utils.update_play_times_duration(play_times, player_state)
-            media_id = previous_data['mediaId']
+            video_track_id = previous_data['videoTrackId']
+            audio_track_id = previous_data['audioTrackId']
+            sub_track_id = previous_data['timedTextTrackId']
 
         params = {
             'event': event_type,
             'xid': previous_data.get('xid', G.LOCAL_DB.get_value('xid', table=TABLE_SESSION)),
-            'position': player_state['elapsed_seconds'] * 1000,  # Video time elapsed
+            'position': position,  # Video time elapsed
             'clientTime': timestamp,
             'sessionStartTime': previous_data.get('sessionStartTime', timestamp),
-            'mediaId': media_id,
+            'videoTrackId': video_track_id,
+            'audioTrackId': audio_track_id,
+            'timedTextTrackId': sub_track_id,
             'trackId': str(event_data['track_id']),
             'sessionId': str(self.session_id),
             'appId': str(self.app_id or self.session_id),

--- a/resources/lib/services/nfsession/msl/msl_utils.py
+++ b/resources/lib/services/nfsession/msl/msl_utils.py
@@ -81,16 +81,14 @@ def update_play_times_duration(play_times, player_state):
     play_times['video'][0]['duration'] = duration
 
 
-def build_media_tag(player_state, manifest):
+def build_media_tag(player_state, manifest, position):
     """Build the playTimes and the mediaId data by parsing manifest and the current player streams used"""
     common.apply_lang_code_changes(manifest['audio_tracks'])
-    duration = player_state['elapsed_seconds'] * 1000
 
     audio_downloadable_id, audio_track_id = _find_audio_data(player_state, manifest)
     video_downloadable_id, video_track_id = _find_video_data(player_state, manifest)
-    # Todo: subtitles data set always as disabled, could be added in future
-    text_track_id = 'T:1:1;1;NONE;0;1;'
-
+    text_track_id = _find_subtitle_data(manifest)
+    duration = position - 1  # 22//11/2021 The duration has the subtracted value of 1
     play_times = {
         'total': duration,
         'audio': [{
@@ -103,11 +101,7 @@ def build_media_tag(player_state, manifest):
         }],
         'text': []
     }
-
-    # Format example: "A:1:1;2;en;1;|V:2:1;2;;default;1;CE3;0;|T:1:1;1;NONE;0;1;"
-    media_id = '|'.join([audio_track_id, video_track_id, text_track_id])
-
-    return play_times, media_id
+    return play_times, video_track_id, audio_track_id, text_track_id
 
 
 def _find_audio_data(player_state, manifest):
@@ -144,6 +138,19 @@ def _find_video_data(player_state, manifest):
     raise Exception(
         f'build_media_tag: unable to find video data with codec: {codec}, width: {width}, height: {height}'
     )
+
+
+def _find_subtitle_data(manifest):
+    """
+    Find the subtitle downloadable id and the subtitle track id
+    """
+    # Todo: is needed to implement the code to find the appropriate data
+    #       for now we always return the "disabled" track
+    for sub_track in manifest['timedtexttracks']:
+        if sub_track['isNoneTrack']:
+            return sub_track['new_track_id']
+    # Not found?
+    raise Exception('build_media_tag: unable to find subtitle data')
 
 
 def generate_logblobs_params():

--- a/resources/lib/services/nfsession/nfsession_ops.py
+++ b/resources/lib/services/nfsession/nfsession_ops.py
@@ -47,8 +47,6 @@ class NFSessionOperations(SessionPathRequests):
             self.activate_profile,
             self.parental_control_data,
             self.get_metadata,
-            self.update_loco_context,
-            self.update_videoid_bookmark,
             self.get_videoid_info
         ]
         # Share the activate profile function to SessionBase class
@@ -228,10 +226,12 @@ class NFSessionOperations(SessionPathRequests):
         #   serverDefs/date/requestId of reactContext nor to request_id of the video event request,
         #   seem to have some kind of relationship with renoMessageId suspect with the logblob but i am not sure.
         #   I noticed also that this request can also be made with the fourth parameter empty.
+        #   The fifth parameter unknown
         params = [common.enclose_quotes(list_id),
                   list_index,
                   common.enclose_quotes(list_context_name),
-                  '']
+                  '""',
+                  '""']
         # path_suffixs = [
         #    [{'from': 0, 'to': 100}, 'itemSummary'],
         #    [['componentSummary']]
@@ -254,6 +254,7 @@ class NFSessionOperations(SessionPathRequests):
         # You can check if this function works through the official android app
         # by checking if the red status bar of watched time position appears and will be updated, or also
         # if continueWatching list will be updated (e.g. try to play a new tvshow not contained in the "my list")
+        # 22/11/2021: This method seem not more used
         call_paths = [['refreshVideoCurrentPositions']]
         params = [f'[{video_id}]', '[]']
         try:
@@ -293,7 +294,8 @@ class NFSessionOperations(SessionPathRequests):
         loco_data = self.path_request([['loco', [context_name], ['context', 'id', 'index']]])
         loco_root = loco_data['loco'][1]
         _loco_data = {'root_id': loco_root}
-        if context_name in loco_data['locos'][loco_root]:
+        # 22/11/2021 With some users the API path request not provide the "locos" data
+        if 'locos' in loco_data and context_name in loco_data['locos'][loco_root]:
             # NOTE: In the new profiles, there is no 'continueWatching' list and no data will be provided
             _loco_data['list_context_name'] = context_name
             _loco_data['list_index'] = loco_data['locos'][loco_root][context_name][2]

--- a/resources/lib/services/playback/am_video_events.py
+++ b/resources/lib/services/playback/am_video_events.py
@@ -91,9 +91,9 @@ class AMVideoEvents(ActionManager):
                 # We do not use _on_playback_started() to send EVENT_START, because the action managers
                 # AMStreamContinuity and AMPlayback may cause inconsistencies with the content of player_state data
 
-                # When the playback starts for the first time, for correctness should send elapsed_seconds value to 0
+                # When the playback starts for the first time, for correctness should send elapsed_seconds value to 1
                 if self.tick_elapsed < 5 and self.event_data['resume_position'] is None:
-                    player_state['elapsed_seconds'] = 0
+                    player_state['elapsed_seconds'] = 1
                 self._send_event(EVENT_START, self.event_data, player_state)
                 self.is_event_start_sent = True
                 self.tick_elapsed = 0


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Some minor changes to the website cause problems with sync watched status to some users, due to missing "locos" data cause an exception to the events_handler

After some tests seem that the website now rarely uses the request with `refreshListByContext` to update the LoCo lists, from 4 playbacks only 1 time has been requested.
Different for `refreshVideoCurrentPositions` i have not found any requests, maybe deprecated.

I've noticed that even without making the update request with `refreshListByContext` the lists are still updated (cross test with addon/android/website), it is possible that (finally) they have improved the system of update of the watched status in more dynamic way that not require a manual callback from the client.

Fix issue #1266

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
