### PR TITLE
New changes to licensed manifest request

### DIFF
--- a/resources/lib/common/device_utils.py
+++ b/resources/lib/common/device_utils.py
@@ -115,7 +115,7 @@ def get_user_agent(enable_android_mediaflag_fix=False):
         # the Windows UA is not limited, so we can use it to get the right video media flags.
         system = 'windows'
 
-    chrome_version = 'Chrome/84.0.4147.136'
+    chrome_version = 'Chrome/96.0.4664.77'
     base = 'Mozilla/5.0 '
     base += '%PL% '
     base += 'AppleWebKit/537.36 (KHTML, like Gecko) '
@@ -127,9 +127,12 @@ def get_user_agent(enable_android_mediaflag_fix=False):
         return base.replace('%PL%', '(Windows NT 10.0; Win64; x64)')
     # ARM based Linux
     machine_arch = get_machine()
-    if machine_arch.startswith('arm') or machine_arch.startswith('aarch'):
+    if machine_arch.startswith('arm'):
         # Last number is the platform version of Chrome OS
-        return base.replace('%PL%', '(X11; CrOS armv7l 13099.110.0)')
+        return base.replace('%PL%', '(X11; CrOS armv7l 14324.33.0)')
+    if machine_arch.startswith('aarch'):
+        # Last number is the platform version of Chrome OS
+        return base.replace('%PL%', '(X11; CrOS aarch64 14324.33.0)')
     # x86 Linux
     return base.replace('%PL%', '(X11; Linux x86_64)')
 

--- a/resources/lib/services/nfsession/msl/msl_handler.py
+++ b/resources/lib/services/nfsession/msl/msl_handler.py
@@ -145,42 +145,47 @@ class MSLHandler:
 
         params = {
             'type': 'standard',
-            'viewableId': [viewable_id],
+            'manifestVersion': 'v2',
+            'viewableId': viewable_id,
             'profiles': profiles,
             'flavor': 'PRE_FETCH',
             'drmType': 'widevine',
             'drmVersion': 25,
             'usePsshBox': True,
             'isBranching': False,
-            'isNonMember': False,
-            'isUIAutoPlay': False,
             'useHttpsStreams': True,
+            'supportsUnequalizedDownloadables': True,
             'imageSubtitleHeight': 1080,
             'uiVersion': G.LOCAL_DB.get_value('ui_version', '', table=TABLE_SESSION),
             'uiPlatform': 'SHAKTI',
             'clientVersion': G.LOCAL_DB.get_value('client_version', '', table=TABLE_SESSION),
-            'desiredVmaf': 'plus_lts',  # phone_plus_exp can be used to mobile, not tested
             'supportsPreReleasePin': True,
             'supportsWatermark': True,
-            'supportsUnequalizedDownloadables': True,
             'showAllSubDubTracks': False,
-            'titleSpecificData': {
-                str(viewable_id): {
-                    'unletterboxed': True
-                }
-            },
             'videoOutputInfo': [{
                 'type': 'DigitalVideoOutputDescriptor',
                 'outputType': 'unknown',
                 'supportedHdcpVersions': hdcp_version,
                 'isHdcpEngaged': hdcp_override
             }],
+            'titleSpecificData': {
+                str(viewable_id): {
+                    'unletterboxed': True
+                }
+            },
             'preferAssistiveAudio': False,
+            'isUIAutoPlay': False,
+            'isNonMember': False,
+            'desiredVmaf': 'plus_lts',  # phone_plus_exp can be used to mobile, not tested
+            'desiredSegmentVmaf': 'plus_lts',
+            'requestSegmentVmaf': False,
+            'supportsPartialHydration': False,
+            'contentPlaygraph': [],
             'profileGroups': [{
                 'name': 'default',
                 'profiles': profiles
             }],
-            'licenseType': 'standard'
+            'licenseType': 'limited'  # standard / limited
         }
         if challenge and sid:
             params['challenge'] = challenge


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
In some countries netflix has started to use a new version of licensed manifest request called as "v2",
without this change this errors will be raised when you try to play a video:

from manifest request:
```
errorDisplayMessage: This title is not available to watch instantly. Please try another title.
code: FAIL
bladeRunnerCode: PLAY_API_ERROR
```

or from license request:

```
errorDisplayMessage: This title is not available to watch instantly. Please try another title.
code: DEVICE_EOL_FINAL
bladeRunnerCode: 3078
```

Ref. issues:
#1278
#1271

(user agent update is not related, add only to not make another PR)

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
