### PR TITLE
Add setting to mark started tv shows as seen

### DIFF
--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Připomenutí nastaveno"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Nové a oblíbené"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Erinnerung gesetzt"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Neu und beliebt"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -1111,3 +1111,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1138,3 +1138,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1111,3 +1111,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Rappel activé"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Nouveautés les plus regardées"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -1113,3 +1113,12 @@ msgstr "Recordatorio establecido"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Novo e popular"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -1111,3 +1111,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -1112,3 +1112,12 @@ msgstr "Podsjetnik postavljen"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Novo i popularno"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Emlékeztető beállítása"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Új és népszerű"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Promemoria attivo"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Nuovi e popolari"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -1111,3 +1111,12 @@ msgstr "リマインダー設定済み"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "新作＆人気作"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -1111,3 +1111,12 @@ msgstr "알림 설정 완료"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "NEW! 요즘 대세 콘텐츠"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1111,3 +1111,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Przypomnienie ustawione"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Nowe i popularne"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Definir Lembrete"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Novo e popular"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -1111,3 +1111,12 @@ msgstr "Memento configurat"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "Nou și popular"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -1111,3 +1111,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -1111,3 +1111,12 @@ msgstr ""
 msgctxt "#30700"
 msgid "New and popular"
 msgstr ""
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -1111,3 +1111,12 @@ msgstr "提醒已设置"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "最新与热播"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -1111,3 +1111,12 @@ msgstr "提醒已設定"
 msgctxt "#30700"
 msgid "New and popular"
 msgstr "最新與熱門"
+
+msgctxt "#30701"
+msgid "Marks started tv shows as seen"
+msgstr ""
+
+# Description of setting ID #30701
+msgctxt "#30702"
+msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, will make items marked as seen not visible."
+msgstr ""

--- a/resources/lib/common/videoid.py
+++ b/resources/lib/common/videoid.py
@@ -201,10 +201,10 @@ class VideoId:
         """Return a dict containing the relevant properties of this
         instance"""
         result = {'mediatype': self.mediatype}
-        result.update({prop: self.__getattribute__(prop)  # pylint: disable=no-member
+        result.update({prop: getattr(self, prop)
                        for prop in ['videoid', 'supplementalid', 'movieid',
                                     'tvshowid', 'seasonid', 'episodeid']
-                       if self.__getattribute__(prop) is not None})  # pylint: disable=no-member
+                       if getattr(self, prop, None) is not None})
         return result
 
     def derive_season(self, seasonid):

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -69,6 +69,8 @@ def add_info_list_item(list_item: ListItemW, videoid, item, raw_data, is_in_myli
         # Highlight ListItem title when the videoid is contained in my-list
         list_item.setLabel(_colorize_text(common_data['mylist_titles_color'], list_item.getLabel()))
     infos_copy['title'] = list_item.getLabel()
+    if videoid.mediatype == common.VideoId.SHOW and not common_data['marks_tvshow_started']:
+        infos_copy.pop('PlayCount', None)
     list_item.setInfo('video', infos_copy)
     list_item.setArt(get_art(videoid, art_item or item or {}, common_data['profile_language_code'],
                              delayed_db_op=True))

--- a/resources/lib/run_addon.py
+++ b/resources/lib/run_addon.py
@@ -149,7 +149,7 @@ def _get_nav_handler(root_handler, pathitems):
 def _execute(executor_type, pathitems, params, root_handler):
     """Execute an action as specified by the path"""
     try:
-        executor = executor_type(params).__getattribute__(pathitems[0] if pathitems else 'root')
+        executor = getattr(executor_type(params), pathitems[0] if pathitems else 'root')
     except AttributeError as exc:
         raise InvalidPathError(f'Unknown action {"/".join(pathitems)}') from exc
     LOG.debug('Invoking action: {}', executor.__name__)

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -261,7 +261,8 @@ def build_video_listing(video_list, menu_data, sub_genre_id=None, pathitems=None
                                 else None),
         'profile_language_code': G.LOCAL_DB.get_profile_config('language', ''),
         'ctxmenu_remove_watched_status': menu_data['path'][1] == 'continueWatching',
-        'active_profile_guid': G.LOCAL_DB.get_active_profile_guid()
+        'active_profile_guid': G.LOCAL_DB.get_active_profile_guid(),
+        'marks_tvshow_started': G.ADDON.getSettingBool('marks_tvshow_started'),
     }
     directory_items = [_create_video_item(videoid_value, video, video_list, perpetual_range_start, common_data)
                        for videoid_value, video

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -56,6 +56,11 @@
                         <dependency type="visible" setting="sync_watched_status">true</dependency>
                     </dependencies>
                 </setting>
+                <setting id="marks_tvshow_started" type="boolean" label="30701" help="30702">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
                 <setting id="mylist_titles_color" type="integer" label="30215" help="">
                     <level>0</level>
                     <default>1</default>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Add setting to mark started tv shows as seen
by default will be disabled to prevent problems with skin filters

fix #1351 

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
