### PR TITLE
Update French translation for v1.18.7

### DIFF
--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1088,7 +1088,7 @@ msgstr "[B]Désactiver ce paramètre causera une faille de sécurité[/B]. Si vo
 
 msgctxt "#30612"
 msgid "MSL manifest version"
-msgstr ""
+msgstr "Version du manifeste MSL"
 
 # Unused 30613 to 30619
 msgctxt "#30620"
@@ -1114,9 +1114,9 @@ msgstr "Nouveautés les plus regardées"
 
 msgctxt "#30701"
 msgid "Marks started tv shows as watched"
-msgstr ""
+msgstr "Marquer les séries démarrées comme vues"
 
 # Description of setting ID #30701
 msgctxt "#30702"
 msgid "Please note that by enabling this setting if filters are enabled in your Skin settings, items marked as watched may not be visible."
-msgstr ""
+msgstr "En activant ce paramètre si des filtres sont activés dans les paramètres de votre thème, les élements marqués comme vus peuvent ne pas être visibles."


### PR DESCRIPTION
Note: I didn't translate "MSL" as the setting associated with [line 1091](https://github.com/thombet/plugin.video.netflix/blob/af47c4cfe23a52bc4b96ae5ba28301a5f9ebdf91/resources/language/resource.language.fr_fr/strings.po#L1091) is in the "expert" section (so I guess if one uses this setting, he/she should know the meaning of this acronym).