### PR TITLE
Allow STRM resume workaround only for Kodi versions below 19.5

### DIFF
--- a/resources/lib/navigation/player.py
+++ b/resources/lib/navigation/player.py
@@ -165,7 +165,9 @@ def _profile_switch():
 
 
 def _strm_resume_workaroud(is_played_from_strm, videoid):
-    """Workaround for resuming STRM files from library"""
+    """Workaround for resuming STRM files from library, for Kodi versions below 19.5"""
+    if G.KODI_VERSION > '19.4':
+        return None
     if not is_played_from_strm or not G.ADDON.getSettingBool('ResumeManager_enabled'):
         return None
     # The resume workaround will fail when:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -834,10 +834,19 @@
             </group>
             <!--GROUP: Library-->
             <group id="2" label="30049">
-                <setting id="ResumeManager_enabled" type="boolean" label="30176" help="">
+                <setting id="ResumeManager_enabled" type="boolean" label="30176" help=""><!-- Needed only to Kodi versions below 19.5 -->
                     <level>0</level>
                     <default>true</default>
                     <control type="toggle"/>
+                    <dependencies>
+                        <dependency type="visible">
+                            <and>
+                                <condition on="property" operator="!is" name="InfoBool">String.StartsWith(System.BuildVersionCode,19.5)</condition>
+                                <condition on="property" operator="!is" name="InfoBool">String.StartsWith(System.BuildVersionCode,19.9)</condition> <!-- v20 pre-releases -->
+                                <condition on="property" operator="!is" name="InfoBool">Integer.IsGreaterOrEqual(System.BuildVersionCode,20)</condition>
+                            </and>
+                        </dependency>
+                    </dependencies>
                 </setting>
                 <setting id="ResumeManager_dialog" type="boolean" label="30177" help="" parent="ResumeManager_enabled">
                     <level>0</level>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
The workaround to allow resume playback with STRM files on kodi library is no longer needed
since i have pushed the fix to Kodi: https://github.com/xbmc/xbmc/pull/21830

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
