### PR TITLE
Keep databases open

### DIFF
--- a/resources/lib/database/db_base_mysql.py
+++ b/resources/lib/database/db_base_mysql.py
@@ -29,18 +29,13 @@ def handle_connection(func):
         if not args[0].is_mysql_database:
             # If database is not mysql pass to next decorator
             return func(*args, **kwargs)
-        conn = None
         try:
             if not args[0].conn or (args[0].conn and not args[0].conn.is_connected()):
                 args[0].conn = mysql.connector.connect(**args[0].config)
-                conn = args[0].conn
             return func(*args, **kwargs)
         except mysql.connector.Error as exc:
             LOG.error('MySQL error {}:', exc)
             raise DBMySQLConnectionError from exc
-        finally:
-            if conn and conn.is_connected():
-                conn.close()
     return wrapper
 
 

--- a/resources/lib/database/db_utils.py
+++ b/resources/lib/database/db_utils.py
@@ -12,6 +12,7 @@ import os
 import xbmcvfs
 
 from resources.lib.globals import G
+from resources.lib.utils.logging import LOG
 
 
 LOCAL_DB_FILENAME = 'nf_local.sqlite3'
@@ -95,3 +96,19 @@ def mysql_insert_or_update(table, id_columns, columns):
     on_duplicate_params = [f'{col} = @{col}' for col in columns]
     query_duplicate = f'ON DUPLICATE KEY UPDATE {", ".join(on_duplicate_params)};'
     return ' '.join([query_set, query_insert, query_duplicate])
+
+
+def is_sqlite3_threadsafe():
+    """
+    Check if SQLite3 module is threadsafe
+    """
+    try:
+        import sqlite3 as sql
+        conn = sql.connect(':memory:')
+        threadsafety = conn.execute('SELECT * FROM pragma_compile_options WHERE compile_options LIKE \'THREADSAFE=%\'').fetchone()[0]
+        conn.close()
+        if int(threadsafety.split("=")[1]) == 1:
+            return True
+    except Exception as exc:  # pylint: disable=broad-except
+        LOG.error('Failed to check sqlite thread safe: {}', exc)
+    return False

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -273,6 +273,9 @@ class GlobalVariables:
         self.IPC_OVER_HTTP = self.ADDON.getSettingBool('enable_ipc_over_http')
 
     def init_database(self):
+        # Check if SQLite module is thread safe
+        from resources.lib.database.db_utils import is_sqlite3_threadsafe
+        self.IS_SQLITE3_THREADSAFE = is_sqlite3_threadsafe()
         # Initialize local database
         import resources.lib.database.db_local as db_local
         self.LOCAL_DB = db_local.NFLocalDatabase()


### PR DESCRIPTION
Try to longer open and close database handles for each operation to speedup operation.

### Check if this PR fulfills these requirements:
* [X] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [X] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [X] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [X] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
This plugin uses sqlite, and optionally, a mysql database.
For both types of databases for each SQL statement a new connection to the database is opened, then the statement gets executed, and then the connection gets immediately closed.

This PR changes this behaviour and keeps the databases open if possible.
For **sqlite** it is checked if the used underlying library is threadsafe (that's the default for the last few years but can be changed at compile time):
If it is, the database is kept open after executing a statement, which leads to a noticeable performance improvement.
If the sqlite library is not threadsafe, the old methodology is used and the database gets closed after every statement to avoid corruption. The check for threadsafety is taken from [Python, SQLite, and thread safety](https://ricardoanderegg.com/posts/python-sqlite-thread-safety/).

For **Mysql/Mariadb** an enormous speedup is achieved, making the Mysql feature usable on slower devices, on which Mysql operations were too slow to be completed before an IPC timeout occurred (Fixes #1408).
As Mysql is always threadsafe, no additional checks are required.

#### Benchmarks:
Following tests were done on a Vero4k+ running OSMC. MySQL server is a Xeon E3-1245 v5 running Mariadb 10.5, connected via wired LAN. The times is the time required to show Netflix "My List" with about 80 entries.

Current code ("open-execute-close"), without optional MySQL database: 3977 ms
Current code ("open-execute-close"), with optional MySQL database: 45739 ms (had to increase IPC timeout to get it working)

New code (DBs kept open), without optional MySQL database: 3258 ms -> **22% faster**
New code (DBs kept open), with optional MySQL database: 4499 ms -> **900% faster**
