### PR TITLE
Fix MSL user authentication

### DIFF
--- a/resources/lib/services/nfsession/msl/msl_request_builder.py
+++ b/resources/lib/services/nfsession/msl/msl_request_builder.py
@@ -11,16 +11,24 @@ import json
 import base64
 import random
 import time
+from typing import TYPE_CHECKING
 
+from resources.lib.common.exceptions import MSLError
 from resources.lib.globals import G
 import resources.lib.common as common
+from resources.lib.services.nfsession.msl.msl_utils import (MSL_AUTH_USER_ID_TOKEN, MSL_AUTH_EMAIL_PASSWORD,
+                                                            MSL_AUTH_NETFLIXID)
 from resources.lib.utils.logging import measure_exec_time_decorator
+
+if TYPE_CHECKING:  # This variable/imports are used only by the editor, so not at runtime
+    from resources.lib.services.nfsession.nfsession_ops import NFSessionOperations
 
 
 class MSLRequestBuilder:
     """Provides mechanisms to create MSL requests"""
 
-    def __init__(self):
+    def __init__(self, nfsession):
+        self.nfsession: 'NFSessionOperations' = nfsession
         self.current_message_id = None
         self.rndm = random.SystemRandom()
         # Set the Crypto handler
@@ -124,14 +132,16 @@ class MSLRequestBuilder:
 
     def _add_auth_info(self, header_data, auth_data):
         """User authentication identifies the application user associated with a message"""
-        # Warning: the user id token contains also contains the identity of the netflix profile
-        # therefore it is necessary to use the right user id token for the request
-        if auth_data.get('user_id_token'):
+        if auth_data['auth_scheme'] == MSL_AUTH_USER_ID_TOKEN:
+            # Authentication scheme with: User ID token
+            # Make requests by using by default main netflix profile, since the user id token contains also the identity
+            # of the netflix profile, to send data to the right profile (e.g. for continue watching) must be used
+            # SWITCH_PROFILE scheme to switching MSL profile.
+            # 25/09/2022: SWITCH_PROFILE auth scheme has been disabled on netflix website backend and not works anymore.
             if auth_data['use_switch_profile']:
-                # The SWITCH_PROFILE is a custom Netflix MSL user authentication scheme
-                # that is needed for switching profile on MSL side
-                # works only combined with user id token and can not be used with all endpoints
-                # after use it you will get user id token of the profile specified in the response
+                # The SWITCH_PROFILE is a custom Netflix MSL user authentication scheme, that is needed for switching
+                # profile on MSL side, works only combined with user id token and can not be used with all endpoints
+                # after use it you will get the user id token of the requested profile in the response.
                 header_data['userauthdata'] = {
                     'scheme': 'SWITCH_PROFILE',
                     'authdata': {
@@ -140,10 +150,10 @@ class MSLRequestBuilder:
                     }
                 }
             else:
-                # Authentication with user ID token containing the user identity (netflix profile)
                 header_data['useridtoken'] = auth_data['user_id_token']
-        else:
-            # Authentication with the user credentials
+        elif auth_data['auth_scheme'] == MSL_AUTH_EMAIL_PASSWORD:
+            # Authentication scheme with: Email password
+            # Make requests by using main netflix profile only (you cannot update continue watching to other profiles)
             credentials = common.get_credentials()
             header_data['userauthdata'] = {
                 'scheme': 'EMAIL_PASSWORD',
@@ -152,13 +162,15 @@ class MSLRequestBuilder:
                     'password': credentials['password']
                 }
             }
-            # Authentication with user Netflix ID cookies
-            # This not works on android,
-            #   will raise: User authentication data does not match entity identity
-            # header_data['userauthdata'] = {
-            #     'scheme': 'NETFLIXID',
-            #     'authdata': {
-            #         'netflixid': cookies['NetflixId'],
-            #         'securenetflixid': cookies['SecureNetflixId']
-            #     }
-            # }
+        elif auth_data['auth_scheme'] == MSL_AUTH_NETFLIXID:
+            # Authentication scheme with: Netflix ID cookies
+            # Make requests by using the same netflix profile used/set on nfsession (website)
+            header_data['userauthdata'] = {
+                'scheme': 'NETFLIXID',
+                'authdata': {
+                    'netflixid': self.nfsession.session.cookies['NetflixId'],
+                    'securenetflixid': self.nfsession.session.cookies['SecureNetflixId']
+                }
+            }
+        else:
+            raise MSLError(f'Authentication scheme "{auth_data["auth_scheme"]}" is not supported.')

--- a/resources/lib/services/nfsession/msl/msl_utils.py
+++ b/resources/lib/services/nfsession/msl/msl_utils.py
@@ -34,6 +34,10 @@ ENDPOINTS = {
     'logblobs': CHROME_PLAYAPI_URL + 'logblob/1'
 }
 
+MSL_AUTH_NETFLIXID = 'NETFLIXID'  # Netflix ID cookies user authentication
+MSL_AUTH_EMAIL_PASSWORD = 'EMAIL_PASSWORD'  # Email password user authentication
+MSL_AUTH_USER_ID_TOKEN = 'USER_ID_TOKEN'  # User ID token user authentication
+
 MSL_DATA_FILENAME = 'msl_data.json'
 
 EVENT_START = 'start'      # events/start : Video starts


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Due to website changes the `SWITCH_PROFILE` auth scheme do not works anymore
by returning `MSLError: Not permitted to switch to the requested user profile`
until today `SWITCH_PROFILE` has been used because in the past `NETFLIXID` auth scheme was not working on android.

Luckily now the `NETFLIXID` auth scheme work on all platforms and simplify a lot of things,
however User ID token auth scheme now need to be revisitied and could be more complex,
but i hope it will not become necessary

Fix #1402

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
