### PR TITLE
Updated android ESN generation

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1187,3 +1187,12 @@ msgstr ""
 msgctxt "#30724"
 msgid "Kodi saves the \"View mode\" \"Zoom\" setting permanently, enable this setting to restore the \"Normal\" View mode when playing a previously watched video."
 msgstr ""
+
+msgctxt "#30725"
+msgid "Force MSL with idtoken authentication"
+msgstr ""
+
+#. Description of setting ID 30725 - do not translate the error message
+msgctxt "#30726"
+msgid "On some Android devices the error \"User authentication data does not match entity identity\" may occur, enabling this setting may solve the problem, but it will only be possible to play videos from the main profile."
+msgstr ""

--- a/resources/lib/services/nfsession/msl/msl_requests.py
+++ b/resources/lib/services/nfsession/msl/msl_requests.py
@@ -170,12 +170,13 @@ class MSLRequests(MSLRequestBuilder):
         auth_data = {}
 
         # TODO: MSL netflixid auth at today not works with L3 android devices by returning error:
-        #  "User authentication data does not match entity identity."
-        #  so we fallback to idtoken auth, but this will not allow to play videos with other profiles than owner one,
-        #  then until another solution will be found the other profiles will be unusable...
-        if get_system_platform() == 'android' and not is_device_l1_enabled():
+        #  "User authentication data does not match entity identity." so we fallback to idtoken auth
+        if get_system_platform() == 'android' and (not is_device_l1_enabled()
+                                                   or G.ADDON.getSettingBool('msl_auth_type')):
             auth_scheme = MSL_AUTH_USER_ID_TOKEN
 
+        # TODO: Due to removal of SWITCH_PROFILE using idtoken authenticaton is possible play videos
+        #  from main/owner profile only
         if auth_scheme == MSL_AUTH_USER_ID_TOKEN:
             auth_data.update(self._check_user_id_token(disable_msl_switch, force_auth_credential))
             if auth_data['user_id_token'] is None:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1023,6 +1023,16 @@
                         <close>true</close>
                     </control>
                 </setting>
+                <setting id="msl_auth_type" type="boolean" label="30725" help="30726">
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition on="property" name="InfoBool">system.platform.android</condition>
+                        </dependency>
+                    </dependencies>
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
                 <setting id="enable_debug" type="boolean" label="30066" help="">
                     <level>0</level>
                     <default>false</default>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
From official app for android / android tv the esn generation is changed
and NFANDROID2 are for android tv case and all others devices NFANDROID1

without access to android API's we have not a safe way to check if we are on android tv OS
so we rely to `ro.build.characteristics` that i hope will cover most of cases

Plus add a new expert setting to force MSL idtoken authentication, this seem to fix playback to some android devices (not certified) but will be not possible the playback from other profiles than the main/owner due to missing MSL profile switching

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
