### PR TITLE
Disable language code workaround on Kodi 20 or above

### DIFF
--- a/resources/lib/common/kodi_ops.py
+++ b/resources/lib/common/kodi_ops.py
@@ -261,7 +261,10 @@ def fix_locale_languages(item):
         # Replace pt-BR with pb, is an unofficial ISO 639-1 Portuguese (Brazil) language code
         # has been added to Kodi 18.7 and Kodi 19.x PR: https://github.com/xbmc/xbmc/pull/17689
         item['language'] = 'pb'
-    if len(item['language']) > 2:
+    # From Kodi v20, this problem has been improved by https://github.com/xbmc/xbmc/pull/21776
+    # it is not needed anymore manually rename country codes to avoid inconsistent descriptions on kodi GUI
+    # and so we allow users to use advancedsettings.xml to specify custom descriptions
+    if G.KODI_VERSION < '20' and len(item['language']) > 2:
         # Replace know locale with country
         # so Kodi will not recognize the modified country code and will show the string as it is
         if item['language'] in LOCALE_CONV_TABLE:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
After kodi PR https://github.com/xbmc/xbmc/pull/21776
the language codes with sub-tags such as country code are no longer displayed in kodi GUI with the wrong descriptions
but remain unchanged

This allow also users to use advancedsettings.xml to define missing language codes
as explained on wiki https://kodi.wiki/view/Advancedsettings.xml#languagecodes

so this workaround is not more needed on Kodi 20 or above

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
