### PR TITLE
Removed use of deprecated setInfo (from Kodi v20)

### DIFF
--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -79,7 +79,7 @@ def add_info_list_item(list_item: ListItemW, videoid, item, raw_data, is_in_myli
     elif is_in_remind_me:
         # Highlight ListItem title when a video is marked as "Remind me"
         list_item.setLabel(_colorize_text(common_data['rememberme_titles_color'], list_item.getLabel()))
-    infos_copy['title'] = list_item.getLabel()
+    infos_copy['Title'] = list_item.getLabel()
     if videoid.mediatype == common.VideoId.SHOW and not common_data['marks_tvshow_started']:
         infos_copy.pop('PlayCount', None)
     list_item.setInfo('video', infos_copy)
@@ -199,7 +199,7 @@ def _parse_referenced_infos(item, raw_data):
 
 def _parse_tags(item):
     """Parse the tags"""
-    return {'tag': [tagdef['name']['value']
+    return {'Tag': [tagdef['name']['value']
                     for tagdef
                     in item.get('tags', {}).values()
                     if isinstance(tagdef.get('name', {}), str)]}
@@ -326,11 +326,11 @@ def set_watched_status(list_item: ListItemW, video_data, common_data):
         except CacheMiss:
             # NOTE shakti 'bookmarkPosition' tag when it is not set have -1 value
             bookmark_position = video_data['bookmarkPosition'].get('value', 0)
-        playcount = '1' if bookmark_position >= watched_threshold else '0'
-        if playcount == '0' and bookmark_position > 0:
+        playcount = 1 if bookmark_position >= watched_threshold else 0
+        if playcount == 0 and bookmark_position > 0:
             resume_time = bookmark_position
     else:
-        playcount = '1' if is_watched_user_overrided else '0'
+        playcount = 1 if is_watched_user_overrided else 0
     # We have to set playcount with setInfo(), because the setProperty('PlayCount', ) have a bug
     # when a item is already watched and you force to set again watched, the override do not work
     list_item.updateInfo({'PlayCount': playcount})

--- a/resources/lib/navigation/directory_search.py
+++ b/resources/lib/navigation/directory_search.py
@@ -265,6 +265,6 @@ def _create_diritem_from_row(row):
     row_id = str(row['ID'])
     search_desc = common.get_local_string(30401) + ': ' + SEARCH_TYPES_DESC.get(row['Type'], 'Unknown')
     list_item = xbmcgui.ListItem(label=row['Value'], offscreen=True)
-    list_item.setInfo('video', {'plot': search_desc})
+    list_item.setInfo('video', {'Plot': search_desc})
     list_item.addContextMenuItems(generate_context_menu_searchitem(row_id, row['Type']))
     return common.build_url(['search', 'search', row_id], mode=G.MODE_DIRECTORY), list_item, True

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -63,7 +63,7 @@ def build_mainmenu_listing(loco_list):
                                 else '')
             list_item = ListItemW(label=menu_title)
             list_item.setArt({'icon': data['icon']})
-            list_item.setInfo('video', {'plot': menu_description})
+            list_item.setInfo('video', {'Plot': menu_description})
             list_item.addContextMenuItems(generate_context_menu_mainmenu(menu_id))
             directory_items.append((common.build_url(data['path'], mode=G.MODE_DIRECTORY), list_item, True))
         # Save the menu titles, to reuse it when will be open the content of menus
@@ -119,7 +119,7 @@ def _create_profile_item(profile_guid, is_selected, is_autoselect, is_autoselect
         'nf_description': description.replace('[CR]', ' - ')
     })
     list_item.setArt({'icon': G.LOCAL_DB.get_profile_config('avatar', '', guid=profile_guid)})
-    list_item.setInfo('video', {'plot': description})
+    list_item.setInfo('video', {'Plot': description})
     list_item.select(is_selected)
     list_item.addContextMenuItems(menu_items)
     return (common.build_url(pathitems=['home'], params={'switch_profile_guid': profile_guid}, mode=G.MODE_DIRECTORY),
@@ -280,7 +280,7 @@ def build_video_listing(video_list, menu_data, sub_genre_id=None, pathitems=None
         # Create the folder for the access to sub-genre
         folder_list_item = ListItemW(label=common.get_local_string(30089))
         folder_list_item.setArt({'icon': 'DefaultVideoPlaylists.png'})
-        folder_list_item.setInfo('video', {'plot': common.get_local_string(30088)})  # The description
+        folder_list_item.setInfo('video', {'Plot': common.get_local_string(30088)})  # The description
         directory_items.insert(0, (common.build_url(['genres', menu_id, sub_genre_id], mode=G.MODE_DIRECTORY),
                                    folder_list_item,
                                    True))

--- a/resources/lib/utils/api_paths.py
+++ b/resources/lib/utils/api_paths.py
@@ -121,7 +121,6 @@ INFO_MAPPINGS = [
 # pylint: disable=unnecessary-lambda
 INFO_TRANSFORMATIONS = {
     'Season': lambda s_value: _convert_season(s_value),
-    'Episode': lambda ep: str(ep),
     'Rating': lambda r: r / 10,
     'PlayCount': lambda w: int(w),
     'Trailer': lambda video_id: common.build_url(pathitems=[common.VideoId.SUPPLEMENTAL, str(video_id)],
@@ -130,18 +129,18 @@ INFO_TRANSFORMATIONS = {
 }
 
 REFERENCE_MAPPINGS = {
-    'cast': 'cast',
-    'director': 'directors',
-    'writer': 'creators',
-    'genre': 'genres'
+    'Cast': 'cast',
+    'Director': 'directors',
+    'Writer': 'creators',
+    'Genre': 'genres'
 }
 
 
 def _convert_season(value):
     if isinstance(value, int):
-        return str(value)
+        return value
     # isdigit is needed to filter out non numeric characters from 'shortName' key
-    return ''.join([n for n in value if n.isdigit()])
+    return int(''.join([n for n in value if n.isdigit()] or '0'))
 
 
 def build_paths(base_path, partial_paths):


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
As title ListItem.setInfo has been deprecated from Kodi v20

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
