### PR TITLE
follow HTTP redirects to fix login in different countries

### DIFF
--- a/resources/lib/services/nfsession/session/base.py
+++ b/resources/lib/services/nfsession/session/base.py
@@ -44,7 +44,7 @@ class SessionBase:
         import httpx
         # (http1=False, http2=True) means that the client know that server support HTTP/2 and avoid to do negotiations,
         # prior knowledge: https://python-hyper.org/projects/hyper-h2/en/v2.3.1/negotiating-http2.html#prior-knowledge
-        self.session = httpx.Client(http1=False, http2=True)
+        self.session = httpx.Client(http1=False, http2=True, follow_redirects=True)
         self.session.max_redirects = 10  # Too much redirects should means some problem
         self.session.headers.update({
             'User-Agent': common.get_user_agent(enable_android_mediaflag_fix=True),


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->

In my country, I could not use this plugin anymore due to a similar error message as described in #1425. However, the fixes there did not help in my case. I checked the log and I saw that the the /login endpoint returned a redirect to /de-en/login in my case. In this commit, I added code to follow redirects in the make_http_call() function. An additional change is necessary in calls to httpx which is also present in the existing PR #1485.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
