### PR TITLE
Allow auto profile selection via query parameter

### DIFF
--- a/resources/lib/navigation/directory.py
+++ b/resources/lib/navigation/directory.py
@@ -60,7 +60,7 @@ class Directory:
             # the update sanitize also relative settings to profiles (see _delete_non_existing_profiles in website.py)
             common.make_call('fetch_initial_page')
         # When the add-on is used in a browser window, we do not have to execute the auto profile selection
-        if not G.IS_ADDON_EXTERNAL_CALL:
+        if not G.IS_ADDON_EXTERNAL_CALL or self.params.get("autoselect_profile") == "True":
             autoselect_profile_guid = G.LOCAL_DB.get_value('autoselect_profile_guid', '')
             if autoselect_profile_guid and not common.WndHomeProps[common.WndHomeProps.IS_CONTAINER_REFRESHED]:
                 if not current_directory:


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [x] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
This small change allows retrieving the default profile's listings via JSON-RPC, by adding parsing of an additional `autoselect_profile` query parameter. This functionality has been added only for the root menu.

The resulting path would be `plugin://plugin.video.netflix/?autoselect_profile=True`.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->
The only way to get the default profile selection behavior (in which the root of the add-on contains the listings for the selected default profile) is to navigate the add-on directly. You cannot point a skin widget at this "default profile" menu, and you cannot retrieve it via JSON-RPC.

#### Describe the new behavior
<!--- Put your text below this line -->
By adding the `autoselect_profile=True` parameter to the root path, it signals to the add-on to display the default profile, even though it isn't being navigated directly.