### PR TITLE
Initial ADS implementation

### DIFF
--- a/resources/lib/services/nfsession/msl/events_handler.py
+++ b/resources/lib/services/nfsession/msl/events_handler.py
@@ -146,7 +146,7 @@ class EventsHandler(threading.Thread):
         # else:
         #     list_id = G.LOCAL_DB.get_value('last_menu_id', 'unknown')
 
-        position = player_state['elapsed_seconds']
+        position = player_state['current_pts']
         if position != 1:
             position *= 1000
 

--- a/resources/lib/services/nfsession/msl/msl_handler.py
+++ b/resources/lib/services/nfsession/msl/msl_handler.py
@@ -123,10 +123,12 @@ class MSLHandler:
                            'This problem could be solved in the future, but at the moment there is no solution.')
                 raise ErrorMsgNoReport(err_msg) from exc
             raise
-        if manifest.get('adverts', {}).get('adBreaks', []):
-            # Todo: manifest converter should handle ads streams with additional DASH periods
-            raise ErrorMsgNoReport('This add-on dont support playback videos with ads. '
-                                   'Please use an account plan without ads.')
+        if G.KODI_VERSION < 20 and manifest.get('adverts', {}).get('adBreaks', []):
+            # InputStream Adaptive version on Kodi 19 is too old and dont handle correctly these manifests
+            raise ErrorMsgNoReport('On Kodi 19 the Netflix ADS plans are not supported. \n'
+                                   'You must use Kodi 20 or higher versions.')
+        if manifest.get('streamingType', 'VOD') != 'VOD':
+            raise ErrorMsgNoReport('Live videos are not supported.')
         return self._tranform_to_dash(manifest)
 
     @measure_exec_time_decorator(is_immediate=True)
@@ -285,7 +287,7 @@ class MSLHandler:
             'requestSegmentVmaf': False,
             'supportsPartialHydration': False,
             'contentPlaygraph': ['start'],
-            'supportsAdBreakHydration': False,
+            'supportsAdBreakHydration': True, # True if this client support separate ADS management, false to use ADS merged on stream (next future?) currently disallowed due to feature not implemented on server side
             'liveMetadataFormat': 'INDEXED_SEGMENT_TEMPLATE',
             'useBetterTextUrls': True,
             'profileGroups': [{

--- a/resources/lib/services/nfsession/msl/msl_utils.py
+++ b/resources/lib/services/nfsession/msl/msl_utils.py
@@ -84,7 +84,7 @@ def is_media_changed(previous_player_state, player_state):
 
 def update_play_times_duration(play_times, player_state):
     """Update the playTimes duration values"""
-    duration = player_state['elapsed_seconds'] * 1000
+    duration = player_state['current_pts'] * 1000
     play_times['total'] = duration
     play_times['audio'][0]['duration'] = duration
     play_times['video'][0]['duration'] = duration

--- a/resources/lib/services/playback/am_playback.py
+++ b/resources/lib/services/playback/am_playback.py
@@ -85,6 +85,8 @@ class AMPlayback(ActionManager):
         self.is_player_in_pause = False
 
     def on_playback_stopped(self, player_state):
+        if player_state['nf_is_ads_stream']:
+            return
         # It could happen that Kodi does not assign as watched a video,
         # this because the credits can take too much time, then the point where playback is stopped
         # falls in the part that kodi recognizes as unwatched (playcountminimumpercent 90% + no-mans land 2%)
@@ -92,7 +94,7 @@ class AMPlayback(ActionManager):
         # In these cases we try change/fix manually the watched status of the video by using netflix offset data
         if int(player_state['percentage']) > 92:
             return
-        if not self.watched_threshold or not player_state['elapsed_seconds'] > self.watched_threshold:
+        if not self.watched_threshold or not player_state['current_pts'] > self.watched_threshold:
             return
         if G.ADDON.getSettingBool('sync_watched_status') and not self.is_played_from_strm:
             # This have not to be applied with our custom watched status of Netflix sync, within the addon

--- a/resources/lib/utils/website.py
+++ b/resources/lib/utils/website.py
@@ -75,6 +75,10 @@ def extract_session_data(content, validate=False, update_profiles=False):
 
     user_data = extract_userdata(react_context)
     _check_membership_status(user_data.get('membershipStatus'))
+    if user_data.get('isAdsPlan') is None:
+        G.LOCAL_DB.delete_key('is_ads_plan', TABLE_SESSION)
+    else:
+        G.LOCAL_DB.set_value('is_ads_plan', user_data['isAdsPlan'], TABLE_SESSION)
 
     api_data = extract_api_data(react_context)
     # Note: Falcor cache does not exist if membershipStatus is not CURRENT_MEMBER


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [ ] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [ ] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [ ] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [ ] I have successfully tested my changes locally

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
The idea is allow to use ADS plan, at least in a more or less acceptable way trying not to make a bad impact on the provider

From website the playback of ADS looks to be a lot customized, which will not make it easy to implement it correctly in the addon

UPDATE 18/11/2023:
After many attemps i found a way to make ADS playable by keeping add-on features amost stable, im not sure that could be 100% stable without Kodi core fixes, this is the situation:

**What done:**
- Support to Kodi 20 and higher (Kodi 19 have too old components)
- ADS are played always before the movie and not in the middle of movie. _This is not a kind of feature_ but a workaround for a complex thing that will need to be solved with the DASH manifest conversion, that currently i dont know how solve.
- If ADS are played in sequence without fast-forwarding the video then add-on features (e.g. language selection, watched status sync, ...) 100% of times will work correctly, _BUT if you try to skip the ADS all add-on features could stop working_. This is one of major problems that cannot be solved, this is because of a big problem on Kodi core about changing chapter and wrong JSON RPC data sent to the addon. The chapter change happens when ISAdaptive addon send in to the buffer DEMUX_SPECIALID_STREAMCHANGE packet event, but looks like Kodi core process this packet without take in account of video buffer consumed or something related, this problem can also be displayed in the Kodi GUI info during playback where show the next chapter info while the current chapter is not ended yet.

**What missing:**
- Is completely missing the backend code that send to the website the playback status of ADS videos
- Implement to ISAdaptive a way to detect ADS, in order to disable Kodi player controls
- The Kodi JSON RPC problems related to DEMUX_SPECIALID_STREAMCHANGE cause impossibility to the add-on to works correctly, and the workarounds implemented to the add-on are not safe, will require future Kodi core fixes

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
