### PR TITLE
fix: Showing "Browse subgenres" folder coming from "Previous page"

### DIFF
--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -268,7 +268,8 @@ def build_video_listing(video_list, menu_data, sub_genre_id=None, pathitems=None
                        for videoid_value, video
                        in video_list.videos.items()]
     # If genre_id exists add possibility to browse LoCo sub-genres
-    if sub_genre_id and sub_genre_id != 'None':
+    # With checking if 'previous_start' is existing, we know that it is the first page
+    if sub_genre_id and sub_genre_id != 'None' and 'previous_start' not in video_list.perpetual_range_selector:
         # Create dynamic sub-menu info in MAIN_MENU_ITEMS
         menu_id = f'subgenre_{sub_genre_id}'
         sub_menu_data = menu_data.copy()

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_utils.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_utils.py
@@ -23,7 +23,7 @@ def add_items_previous_next_page(directory_items, pathitems, perpetual_range_sel
     if pathitems and perpetual_range_selector:
         if 'previous_start' in perpetual_range_selector:
             params = {'perpetual_range_start': perpetual_range_selector.get('previous_start'),
-                      'sub_genre_id': sub_genre_id if perpetual_range_selector.get('previous_start') == 0 else None}
+                      'sub_genre_id': sub_genre_id}
             if path_params:
                 params.update(path_params)
             previous_page_item = ListItemW(label=common.get_local_string(30148))
@@ -33,7 +33,8 @@ def add_items_previous_next_page(directory_items, pathitems, perpetual_range_sel
                                        previous_page_item,
                                        True))
         if 'next_start' in perpetual_range_selector:
-            params = {'perpetual_range_start': perpetual_range_selector.get('next_start')}
+            params = {'perpetual_range_start': perpetual_range_selector.get('next_start'),
+                      'sub_genre_id': sub_genre_id}
             if path_params:
                 params.update(path_params)
             next_page_item = ListItemW(label=common.get_local_string(30147))


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Fixes: #1660

"Browse Subgenres" folder was not available if the first page was opened over "Previous page".
The subgenres_id was not passed to the next page, so it was not possible to re-create the "Subgenres" folder after clicking "Previous page".
Now the subgenres_id is always passed but the folder "Browse Subgenres" is only on the first page visible. The first page is detected over `'previous_start' not in video_list.perpetual_range_selector`

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
Before:
![kodi_subgenres](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/85ae4eb1-dfaf-437a-b81c-201fcbef1672)