### PR TITLE
Wrong response count in lists causes showing "Next page"

### DIFF
--- a/resources/lib/utils/api_paths.py
+++ b/resources/lib/utils/api_paths.py
@@ -324,7 +324,8 @@ def jgrapgh_len(data_dict):
     """
     count = 0
     for value in data_dict:
-        if data_dict[value].get('$type') == 'atom':
+        ref = _remove_nesting(data_dict[value])
+        if ref.get('$type') == 'atom':
             break
         count += 1
     return count


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Fixes: #1659

**"Lists of all kinds" / "TV show genres"** have the "Next page" folder but there are no entries anymore.

This is caused because the `response_count` is higher then the `requested size`. 
https://github.com/CastagnaIT/plugin.video.netflix/blob/1b7dc6fe5166a0ddc5d86f835d33fa4d44d35b7c/resources/lib/services/nfsession/session/path_requests.py#L75-L77

After parsing in `VideoListSorted` only **two** entries are existing, so `response_count` is counted wrong.

The counting happens here:
https://github.com/CastagnaIT/plugin.video.netflix/blob/1b7dc6fe5166a0ddc5d86f835d33fa4d44d35b7c/resources/lib/utils/api_paths.py#L319-L330

The response from the api looks like this:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/068cad35-5f97-4351-a0bd-bd008de8e028)

The issue is now that we have here nested entries with the property `reference` which contains then the `type`. But the count logic checks if the `type` is a direct child of the entry.
That causes that nested entries without reference are counted too.

**Solution:** remove the nesting and then check if a reference is existing

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
Before:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/d0ebb6a9-7749-4f45-bcae-b92c5991eee1)

After:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/6e5a575c-1038-43fc-9027-b677ef74c702)
