### PR TITLE
Ignore empty cast names

### DIFF
--- a/resources/lib/common/kodi_wrappers.py
+++ b/resources/lib/common/kodi_wrappers.py
@@ -167,7 +167,7 @@ def set_video_info_tag(info: Dict[str, str], video_info_tag: xbmc.InfoTagVideo):
     # From Kodi v20 ListItem.setInfo is deprecated, we need to use the methods of InfoTagVideo object
     # "Cast" and "Tag" keys need to be converted
     cast_names = info.pop('Cast', [])
-    video_info_tag.setCast([xbmc.Actor(name) for name in cast_names])
+    video_info_tag.setCast([xbmc.Actor(name) for name in cast_names if name])
     tag_names = info.pop('Tag', [])
     video_info_tag.setTagLine(' / '.join(tag_names))
     for key, value in info.items():

--- a/resources/lib/common/kodi_wrappers.py
+++ b/resources/lib/common/kodi_wrappers.py
@@ -167,7 +167,7 @@ def set_video_info_tag(info: Dict[str, str], video_info_tag: xbmc.InfoTagVideo):
     # From Kodi v20 ListItem.setInfo is deprecated, we need to use the methods of InfoTagVideo object
     # "Cast" and "Tag" keys need to be converted
     cast_names = info.pop('Cast', [])
-    video_info_tag.setCast([xbmc.Actor(name) for name in cast_names if name])
+    video_info_tag.setCast([xbmc.Actor(name) for name in cast_names])
     tag_names = info.pop('Tag', [])
     video_info_tag.setTagLine(' / '.join(tag_names))
     for key, value in info.items():

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -171,6 +171,9 @@ def parse_info(videoid, item, raw_data, common_data):
     infos.update(_parse_referenced_infos(item, raw_data))
     infos.update(_parse_tags(item))
 
+    if infos['Cast']:
+        infos['Cast'] = [name for name in infos['Cast'] if name]
+
     if videoid.mediatype == common.VideoId.EPISODE:
         # 01/12/2022: The 'delivery' info in the episode data are wrong (e.g. wrong resolution)
         # as workaround we get the 'delivery' info from tvshow data


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Fixes: #1655

"Error TypeError: Actor: name property must not be empty" occurs.

This happens if the Cast has some empty entries.
For example the movie `Misfit`:
```
{
   "Title":"Misfit",
   "Cast":[
      "Selina Mour",
      "Lion Wasczyk",
      "Lisa-Marie Koroll",
      "Jonathan Elias Weiske",
      "Vivien Wulf",
      "Meriel Hinsching",
      "",
      "Moritz Schirdewahn",
      "Simon Will",
      "Sylvie Meis"
   ],
...
```