### PR TITLE
Fix bug if perpetual_range_selector is None

### DIFF
--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -269,7 +269,7 @@ def build_video_listing(video_list, menu_data, sub_genre_id=None, pathitems=None
                        in video_list.videos.items()]
     # If genre_id exists add possibility to browse LoCo sub-genres
     # With checking if 'previous_start' is existing, we know that it is the first page
-    if sub_genre_id and sub_genre_id != 'None' and 'previous_start' not in video_list.perpetual_range_selector:
+    if sub_genre_id and sub_genre_id != 'None' and (not video_list.perpetual_range_selector or 'previous_start' not in video_list.perpetual_range_selector):
         # Create dynamic sub-menu info in MAIN_MENU_ITEMS
         menu_id = f'subgenre_{sub_genre_id}'
         sub_menu_data = menu_data.copy()


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Follow up of: #1660 
In some cases is `video_list.perpetual_range_selector`  `None`. We need to check if it is not `None` and only then check if it has not  `previous_start`

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->

#### Describe the new behavior
<!--- Put your text below this line -->

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->
