### PR TITLE
Feature: Show current episode in season list and mark current episode in episode list

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -845,7 +845,13 @@ msgctxt "#30216"
 msgid "Color of the titles marked as \"Remind me\""
 msgstr ""
 
-#. Unused 30217 to 30218
+msgctxt "#30217"
+msgid "Color of the title of the current episode in a season"
+msgstr "
+
+msgctxt "#30218"
+msgid "Show the current episode in the season list"
+msgstr "
 
 msgctxt "#30219"
 msgid "Disable notification for synchronization completed"

--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -69,11 +69,14 @@ def get_info(videoid, item, raw_data, profile_language_code='', delayed_db_op=Fa
 
 
 def add_info_list_item(list_item: ListItemW, videoid, item, raw_data, is_in_mylist, common_data, art_item=None,
-                       is_in_remind_me=False):
+                       is_in_remind_me=False, is_current_episode=False):
     """Add infolabels and art to a ListItem"""
     infos, quality_infos = get_info(videoid, item, raw_data, delayed_db_op=True, common_data=common_data)
     list_item.addStreamInfoFromDict(quality_infos)
-    if is_in_mylist and common_data.get('mylist_titles_color'):
+    if is_current_episode and common_data.get('current_episode_titles_color'):
+        # Highlight ListItem title when it is the current episode of the season
+        list_item.setLabel(_colorize_text(common_data['current_episode_titles_color'], list_item.getLabel()))
+    elif is_in_mylist and common_data.get('mylist_titles_color'):
         # Highlight ListItem title when the videoid is contained in "My list"
         list_item.setLabel(_colorize_text(common_data['mylist_titles_color'], list_item.getLabel()))
     elif is_in_remind_me:

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder.py
@@ -66,13 +66,21 @@ class DirectoryBuilder(DirectoryPathRequests):
     def get_seasons(self, pathitems, tvshowid_dict, perpetual_range_start):
         tvshowid = VideoId.from_dict(tvshowid_dict)
         season_list = self.req_seasons(tvshowid, perpetual_range_start=perpetual_range_start)
-        return build_season_listing(season_list, tvshowid, pathitems)
+        if len(season_list.seasons) > 1 and G.ADDON.getSettingBool('show_current_episode'):
+            current_episode = self.req_current_episode(season_list.current_seasonid)
+        else:
+            current_episode = None
+        return build_season_listing(season_list, tvshowid, current_episode, pathitems)
 
     @measure_exec_time_decorator(is_immediate=True)
     def get_episodes(self, pathitems, seasonid_dict, perpetual_range_start):
         seasonid = VideoId.from_dict(seasonid_dict)
         episodes_list = self.req_episodes(seasonid, perpetual_range_start=perpetual_range_start)
-        return build_episode_listing(episodes_list, seasonid, pathitems)
+        if G.ADDON.getSettingInt('current_episode_titles_color') > 0:
+            current_episode = self.req_current_episode(seasonid)
+        else:
+            current_episode = None
+        return build_episode_listing(episodes_list, seasonid, current_episode, pathitems)
 
     @measure_exec_time_decorator(is_immediate=True)
     def get_video_list(self, list_id, menu_data, is_dynamic_id):

--- a/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_builder_items.py
@@ -129,11 +129,32 @@ def _create_profile_item(profile_guid, is_selected, is_autoselect, is_autoselect
 
 
 @measure_exec_time_decorator(is_immediate=True)
-def build_season_listing(season_list, tvshowid, pathitems=None):
+def build_season_listing(season_list, tvshowid, current_episode=None, pathitems=None):
     """Build a season listing"""
     common_data = get_common_data()
     directory_items = [_create_season_item(tvshowid, seasonid_value, season, season_list, common_data)
                        for seasonid_value, season in season_list.seasons.items()]
+
+    if current_episode:
+        common_data_episode = get_common_data()
+        common_data_episode['params'] = get_param_watched_status_by_profile()
+        common_data_episode['set_watched_status'] = G.ADDON.getSettingBool('sync_watched_status')
+        common_data_episode['active_profile_guid'] = G.LOCAL_DB.get_active_profile_guid()
+
+        episodeid_value, episode_data = current_episode.episode
+        current_episode_item = _create_episode_item(season_list.current_seasonid, episodeid_value, episode_data, current_episode, common_data_episode)
+        list_item = current_episode_item[1]
+            
+        if list_item.getProperty('isPlayable') == 'true':
+            episode_summary = episode_data['summary']['value']
+            label = f"{episode_summary['season']}x{episode_summary['episode']:02d}. {episode_data['title']['value']}"
+            list_item.setLabel(label)
+
+            episodeid = season_list.current_seasonid.derive_episode(episodeid_value)
+            add_info_list_item(list_item, episodeid, episode_data, current_episode.data, False, common_data_episode)
+
+            directory_items.insert(0, current_episode_item)
+
     # add_items_previous_next_page use the new value of perpetual_range_selector
     add_items_previous_next_page(directory_items, pathitems, season_list.perpetual_range_selector, tvshowid)
     G.CACHE_MANAGEMENT.execute_pending_db_ops()
@@ -151,14 +172,20 @@ def _create_season_item(tvshowid, seasonid_value, season, season_list, common_da
 
 
 @measure_exec_time_decorator(is_immediate=True)
-def build_episode_listing(episodes_list, seasonid, pathitems=None):
+def build_episode_listing(episodes_list, seasonid, current_episode=None, pathitems=None):
     """Build a episodes listing of a season"""
     common_data = get_common_data()
     common_data['params'] = get_param_watched_status_by_profile()
     common_data['set_watched_status'] = G.ADDON.getSettingBool('sync_watched_status')
     common_data['active_profile_guid'] = G.LOCAL_DB.get_active_profile_guid()
 
-    directory_items = [_create_episode_item(seasonid, episodeid_value, episode, episodes_list, common_data)
+    if current_episode:
+        common_data['current_episode_titles_color'] = get_color_name(G.ADDON.getSettingInt('current_episode_titles_color'))
+        current_episodeid_value = current_episode.episode[0]
+    else:
+        current_episodeid_value = None
+
+    directory_items = [_create_episode_item(seasonid, episodeid_value, episode, episodes_list, common_data, current_episodeid_value == episodeid_value)
                        for episodeid_value, episode
                        in episodes_list.episodes.items()]
     # add_items_previous_next_page use the new value of perpetual_range_selector
@@ -168,7 +195,7 @@ def build_episode_listing(episodes_list, seasonid, pathitems=None):
         'title': f'{episodes_list.tvshow["title"]["value"]} - {episodes_list.season["summary"]["value"]["name"]}'}
 
 
-def _create_episode_item(seasonid, episodeid_value, episode, episodes_list, common_data):
+def _create_episode_item(seasonid, episodeid_value, episode, episodes_list, common_data, is_current_episode=False):
     is_playable = episode['availability'].get('value', {}).get('isPlayable', False)
     episodeid = seasonid.derive_episode(episodeid_value)
     list_item = ListItemW(label=episode['title']['value'])
@@ -176,7 +203,7 @@ def _create_episode_item(seasonid, episodeid_value, episode, episodes_list, comm
         'isPlayable': str(is_playable).lower(),
         'nf_videoid': episodeid.to_string()
     })
-    add_info_list_item(list_item, episodeid, episode, episodes_list.data, False, common_data)
+    add_info_list_item(list_item, episodeid, episode, episodes_list.data, False, common_data, None, False, is_current_episode)
     set_watched_status(list_item, episode, common_data)
     if is_playable:
         url = common.build_url(videoid=episodeid, mode=G.MODE_PLAY, params=common_data['params'])

--- a/resources/lib/services/nfsession/directorybuilder/dir_path_requests.py
+++ b/resources/lib/services/nfsession/directorybuilder/dir_path_requests.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from resources.lib import common
 from resources.lib.utils.data_types import (VideoListSorted, SubgenreList, SeasonList, EpisodeList, LoCo, VideoList,
                                             SearchVideoList, CustomVideoList, LoLoMoCategory, VideoListSupplemental,
-                                            VideosList)
+                                            VideosList, CurrentEpisode)
 from resources.lib.common.exceptions import InvalidVideoListTypeError, InvalidVideoId
 from resources.lib.utils.api_paths import (VIDEO_LIST_PARTIAL_PATHS, RANGE_PLACEHOLDER, VIDEO_LIST_BASIC_PARTIAL_PATHS,
                                            SEASONS_PARTIAL_PATHS, EPISODES_PARTIAL_PATHS, ART_PARTIAL_PATHS,
@@ -140,6 +140,24 @@ class DirectoryPathRequests:
         }
         path_response = self.nfsession.perpetual_path_request(**call_args)
         return EpisodeList(videoid, path_response)
+    
+    def req_current_episode(self, videoid):
+        """Retrieve the current episode of a season"""
+        if videoid.mediatype != common.VideoId.SEASON:
+            raise InvalidVideoId(f'Cannot request episode list for {videoid}')
+        LOG.debug('Requesting current episode for {}', videoid)
+        paths = ([['seasons', videoid.seasonid, 'summary']] +
+                 [['seasons', videoid.seasonid, 'componentSummary']] +
+                 build_paths(['seasons', videoid.seasonid, 'episodes', 'current'], EPISODES_PARTIAL_PATHS) +
+                 build_paths(['videos', videoid.tvshowid], ART_PARTIAL_PATHS + [[['title', 'delivery']]]))
+        
+        call_args = {
+            'paths': paths,
+            'length_params': ['stdlist_wid', ['seasons', videoid.seasonid, 'episodes']]
+        }
+        path_response = self.nfsession.perpetual_path_request(**call_args)
+
+        return CurrentEpisode(videoid, path_response)
 
     @cache_utils.cache_output(cache_utils.CACHE_COMMON, identify_append_from_kwarg_name='perpetual_range_start',
                               ignore_self_class=True)

--- a/resources/lib/utils/api_paths.py
+++ b/resources/lib/utils/api_paths.py
@@ -70,7 +70,7 @@ GENRE_PARTIAL_PATHS = [
 SEASONS_PARTIAL_PATHS = [
     ['seasonList', RANGE_PLACEHOLDER, 'summary'],
     ['title'],
-    ["seasonList","current","episodes","current","summary"]
+    ["seasonList","current"]
 ] + ART_PARTIAL_PATHS
 
 EPISODES_PARTIAL_PATHS = [

--- a/resources/lib/utils/api_paths.py
+++ b/resources/lib/utils/api_paths.py
@@ -69,7 +69,8 @@ GENRE_PARTIAL_PATHS = [
 
 SEASONS_PARTIAL_PATHS = [
     ['seasonList', RANGE_PLACEHOLDER, 'summary'],
-    ['title']
+    ['title'],
+    ["seasonList","current","episodes","current","summary"]
 ] + ART_PARTIAL_PATHS
 
 EPISODES_PARTIAL_PATHS = [
@@ -174,6 +175,10 @@ def iterate_references(source):
             continue
         yield (index, path)
 
+    if 'current' in source:
+        path = reference_path(source['current'])
+        if path is not None:
+            yield ('current', path)
 
 def count_references(source):
     counter = 0

--- a/resources/lib/utils/data_types.py
+++ b/resources/lib/utils/data_types.py
@@ -255,6 +255,11 @@ class SeasonList:
         self.tvshow = self.data['videos'][self.videoid.tvshowid]
         self.seasons = OrderedDict(
             resolve_refs(self.tvshow['seasonList'], self.data))
+        if self.tvshow['seasonList']['current']:
+            self.current_seasonid_vaule = self.tvshow['seasonList']['current']['value'][1]
+            self.current_seasonid = videoid.derive_season(self.current_seasonid_vaule)
+            self.current_season = self.seasons[self.current_seasonid_vaule]
+            self.current_episodeid_value = int(self.current_season['episodes']['current']['value'][1])
 
 
 class EpisodeList:
@@ -269,6 +274,13 @@ class EpisodeList:
         self.episodes = OrderedDict(
             resolve_refs(self.season['episodes'], self.data))
 
+class CurrentEpisode:
+    def __init__(self, videoid, path_response):
+        self.data = path_response
+        self.videoid = videoid
+        self.tvshow = self.data['videos'][self.videoid.tvshowid]
+        self.season = self.data['seasons'][self.videoid.seasonid]
+        self.episode = next(resolve_refs(self.season['episodes'], self.data))
 
 class SubgenreList:
     """A list of subgenre."""

--- a/resources/lib/utils/data_types.py
+++ b/resources/lib/utils/data_types.py
@@ -255,11 +255,8 @@ class SeasonList:
         self.tvshow = self.data['videos'][self.videoid.tvshowid]
         self.seasons = OrderedDict(
             resolve_refs(self.tvshow['seasonList'], self.data))
-        if self.tvshow['seasonList']['current']:
-            self.current_seasonid_vaule = self.tvshow['seasonList']['current']['value'][1]
-            self.current_seasonid = videoid.derive_season(self.current_seasonid_vaule)
-            self.current_season = self.seasons[self.current_seasonid_vaule]
-            self.current_episodeid_value = int(self.current_season['episodes']['current']['value'][1])
+        if 'current' in self.tvshow['seasonList']:
+            self.current_seasonid = videoid.derive_season(self.tvshow['seasonList']['current']['value'][1])
 
 
 class EpisodeList:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -64,6 +64,11 @@
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
+                <setting id="show_current_episode" type="boolean" label="30218">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle"/>
+                </setting>
                 <setting id="mylist_titles_color" type="integer" label="30215" help="">
                     <level>0</level>
                     <default>1</default>
@@ -101,6 +106,23 @@
                 <setting id="supplemental_info_color" type="integer" label="30239" help="">
                     <level>0</level>
                     <default>3</default>
+                    <constraints>
+                        <options>
+                            <option label="13106">0</option>
+                            <option label="762">1</option>
+                            <option label="13343">2</option>
+                            <option label="13341">3</option>
+                            <option label="761">4</option>
+                            <option label="760">5</option>
+                            <option label="731">6</option>
+                            <option label="767">7</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="current_episode_titles_color" type="integer" label="30217" help="">
+                    <level>0</level>
+                    <default>5</default>
                     <constraints>
                         <options>
                             <option label="13106">0</option>


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Motivation: It would be very nice if it would be possible to resume the current episode or start the next episode of a tv show from the start screen / tv show overview. Like on the Netflix website. Currently I always need to remember at which season I'm and then I need to scroll down to select the episode after the last watched one.

### In case of Feature change / Breaking change:
#### Describe the current behavior
<!--- Put your text below this line -->
1. select tv show
2. season list is visible
3. select season in season list
4. episode list is visible
5. scroll manually down to the last watched episode

#### Describe the new behavior
<!--- Put your text below this line -->
1. select tv show
2. season list and the current episode is visible
3. current epsiode can be started directly or season can be selected
4. episode list is visible
5. scroll manually down to the episode of which the title has a color


* Showing the current epsiode in the season list can be disabled via settings. Default: true
* The color of the current episode in the episode list can be changed / disabled via settings. Default: Yellow
* For tv shows with only one season the current episode will be not added in the season list (because there is no season list, opens directly the episode list)
* The current episode will be marked in each season, because Netflix has for each season a last watched episode.
* If the current episode is not playable, then it will be not added to the season list
* If there is no current episode, Netflix automatically returns the first episode of the first season.

### Screenshots (if appropriate):
<!--- Add some screenshots if they can be useful to show the differences between before and after the changes -->

Current episode in season list:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/d9322524-e184-46c6-8c74-b7b59a0ecbe4)

Colorized title of the current episode:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/d8fdb32b-8d62-423c-922a-f736df4a4154)

Settings:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/e9efa186-9863-464d-bf46-5f285d885d0e)

Netflix:
![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/cba16b74-846d-46ba-adc8-62f850958cef)

![grafik](https://github.com/CastagnaIT/plugin.video.netflix/assets/19800037/76fe85e4-28c0-4ac9-99de-2b15eb73b8cb)


# Open tasks:
@CastagnaIT I need some help with the following points and the commented code sections:
- [ ] For the current episode in the season list, I added hard-coded the season and episode number. Kodi adds from it self the number in the episode list. `4x08.` is that ok?
- [ ] Translation: How does it work with the translation? I took the unused numbers 30217 and 30218 and only added the text in the `en_gb` translation. Is that ok or does every translation file need the new entries?
- [ ] In `__init__` of `SeasonList` I added new lines. But I don't know if there is a cleaner way.
- [ ] I have not added a cache annotation to `req_current_episode`. I'm not sure if this is needed
