### PR TITLE
Solve issue with missing art

### DIFF
--- a/resources/lib/common/kodi_wrappers.py
+++ b/resources/lib/common/kodi_wrappers.py
@@ -79,6 +79,9 @@ class ListItemW(xbmcgui.ListItem):
                 total_time = float(state['properties'].pop('TotalTime', 0))
                 video_info.setResumePoint(resume_time, total_time)
         super().setProperties(state['properties'])
+        for part in ['thumb', 'landscape']:
+            if part not in state['art'] or state['art'][part] == {}:
+                state['art'][part] = ''
         super().setArt(state['art'])
         super().addContextMenuItems(state.get('context_menus', []))
         super().select(state.get('is_selected', False))


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
When encountering a movie with missing image data, we'd get `EXCEPTION: argument "value" for method "setArt" must be unicode or str`. This is because that's sometimes an empty dict rather than a string. This converts `{}` to `""` to resolve the issue.

### In case of Feature change / Breaking change:
#### Steps to reproduce the bug

Open the Netflix plugin and perform a search for "The Meg". At least at the moment, this will result in an error:

> EXCEPTION: argument "value" for method "setArt" must be unicode or str

This is because there is missing data in the `state['art']` dictionary for The Meg. Even if you're searching for something else, this particular entry causes the problem. If you alter the code to dump the JSON to a log, you'll see this:

```json
{
  "poster": "",
  "fanart": "https://occ-0-2705-2706.1.nflxso.net/dnm/api/v6/…OwQw.jpg?r=b36",
  "thumb": {},
  "landscape": {},
  "clearlogo": "https://occ-0-2705-2706.1.nflxso.net/dnm/api/v6/…klWQ.png?r=3ae"
}
```

(I loaded the `clearlogo` to determine which movie's metadata was broken. Apologies for the truncated paths, I'm not sure if there's anything in there that would identify my account.)

As a result, you cannot see *any* search results that happen to include the broken item, even if it's quite a bit down the list.


#### Describe the new behavior

The new code simply replaces empty `dict` entries with empty `str` entries. You get the placeholder icon in place of the missing content (the poster in my view). Suboptimal, but I don't know how we can get better (I assume it's a Netflix bug).

Note, I didn't dig too hard to see how this dict was populated. Maybe there's a better place for the fix, but my solution certainly solves the issue (though it doesn't find replacements for the missing images).