### PR TITLE
[infolabels] Make sure that parsed persons have a name

### DIFF
--- a/resources/lib/kodi/infolabels.py
+++ b/resources/lib/kodi/infolabels.py
@@ -204,7 +204,8 @@ def _parse_referenced_infos(item, raw_data):
     resolved within the raw data"""
     return {target: [person['name']['value']
                      for _, person
-                     in paths.resolve_refs(item.get(source, {}), raw_data)]
+                     in paths.resolve_refs(item.get(source, {}), raw_data)
+                     if person['name']['value']]
             for target, source in paths.REFERENCE_MAPPINGS.items()}
 
 


### PR DESCRIPTION
### Check if this PR fulfills these requirements:
* [ ] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [ ] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [ ] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [ ] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
<!--- Motivation and a possible detailed explanation of the changes -->
<!--- Put your text below this line -->
Looks like we have found one of website bugs,
on the second response of the requested menu list
[data2.json](https://github.com/CastagnaIT/plugin.video.netflix/files/13853024/data2.json)
the "person" list have the ID 60008166 that have a empty value on "name" field
this should not happens but yeah one of many website weirdness
```py
            "60008166": {
                "id": {
                    "$type": "atom",
                    "value": 60008166
                },
                "name": {
                    "$type": "atom",
                    "value": ""
                }
            },
```

the change take care that all values taken from "person" list are not empty

fix #1655
superseeds #1664