### PR TITLE
Buf fix (ESN parsing): Update xmldialog_esnwidevine.py

### DIFF
--- a/resources/lib/kodi/ui/xmldialog_esnwidevine.py
+++ b/resources/lib/kodi/ui/xmldialog_esnwidevine.py
@@ -115,10 +115,10 @@ class ESNWidevine(xbmcgui.WindowXMLDialog):
     def _esn_checks(self, esn):
         """Sanity checks for ESN"""
         if self.is_android:
-            if not esn.startswith(('NFANDROID1-PRV-', 'NFANDROID2-PRV-')) or esn.count('-') < 5:
+            if not esn.startswith(('NFANDROID1-PRV-', 'NFANDROID2-PRV-', 'NFANDROID3-PRV-', 'NFANDROID4-PRV-')) or esn.count('-') < 5:
                 return False
         else:
-            if esn.count('-') != 3 or len(esn) != 40:
+            if esn.count('-') != 2 or len(esn) != 40:
                 return False
         return True
 


### PR DESCRIPTION
Thanks for the add-on.
This is my first bug fix pull request, after founding a couple of lines to be changed when investigating current add-on problems (no video playback after 2 mins).

Description:
1. Please, note that valid Web browser ESN have only 2 '-' (the same format generated when resetting settings).

2. Also, additional Android patterns are used today (as you can check decompiling APK from https://github.com/aidanmacgregor/Netflix_ATV_L3_DRM_Uncertified_Mod).

Final Note:
This changes will allow users to test additional ESNs on different platforms to see if it affects the playback issue.

Regards!