### PR TITLE
Website parsing error: unable to extract reactContext.

### DIFF
--- a/resources/lib/utils/website.py
+++ b/resources/lib/utils/website.py
@@ -56,7 +56,7 @@ PAGE_ITEMS_API_URL = {
 PAGE_ITEM_ERROR_CODE = 'models/flow/data/fields/errorCode/value'
 PAGE_ITEM_ERROR_CODE_LIST = 'models\\i18nStrings\\data\\login/login'
 
-JSON_REGEX = r'netflix\.{}\s*=\s*(.*?);\s*</script>'
+JSON_REGEX = r'^.*netflix\.{}\s*=\s*(.*?);\s*</script>.*$'
 AVATAR_SUBPATH = ['images', 'byWidth', '320']
 
 PROFILE_DEBUG_INFO = ['isAccountOwner', 'isActive', 'isKids', 'maturityLevel', 'language']


### PR DESCRIPTION
Fixes regex capture problem that prevents the JSON data from loading correctly. 

### Check if this PR fulfills these requirements:
* [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
* [x] I have read the [**CONTRIBUTING**](../../master/Contributing.md) document.
* [x] I made sure there wasn't another [Pull Request](../../../pulls) opened for the same update/change
* [x] I have successfully tested my changes locally

#### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature change (non-breaking change which changes behaviour of an existing functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (non-breaking performance or readability improvements)

### Description
After getting a correct login for my daughter's Standard plan Netflix subscription using the NFAuthentication flle,
Kodi would greet me with the WebsiteParsingError: Unable to extract reactContext message.
This error was already reported before here:
https://github.com/CastagnaIT/plugin.video.netflix/issues/1726
https://github.com/CastagnaIT/plugin.video.netflix/issues/1711
https://github.com/CastagnaIT/plugin.video.netflix/issues/1706

I already spotted those issues because getting the NFAuthentication key login to work took a little time.
https://github.com/CastagnaIT/plugin.video.netflix/wiki/Login-with-Authentication-key
[NFAuthentication.key generation with Firefox](https://github.com/CastagnaIT/plugin.video.netflix/discussions/1632)

I got the login working after making sure Kodi was using the plugin.video.netflix-1.23.3+matrix.1 version, by going into the Addon options and selecting this version. 
After realizing the login worked, I started preparing for some debugging on my LibreElec machine.
I made some changes in the plugin code to log the contents of the response from the Netflix server and see why the code failed.
The website returned/returns JSON data for the reactContext blob followed by  `</script><script>window.netflix = window.netflix || {};</script>`
The plugin script expects to find `netflix.reactContext` and `netflix.falcorCache` JSON array assignments inside `<script>` tags and those tags were causing the problem. The original regex would select including the last `</script>` on a line returned by the server and this would mean the JSON deserialization would fail because of the trailing script tags.

We have tested the change by watching several episodes in HD without issue and also checked that the two stream limit for the Standard plan was properly checked. The error message that was designed to handle this, showed up.

### In case of Feature change / Breaking change:
#### Describe the current behavior
N/A

#### Describe the new behavior
N/A

### Screenshots (if appropriate):
N/A
