### PR TITLE
Fix profile switching by replacing API call

### DIFF
--- a/resources/lib/services/nfsession/nfsession_ops.py
+++ b/resources/lib/services/nfsession/nfsession_ops.py
@@ -17,7 +17,7 @@ import resources.lib.utils.website as website
 from resources.lib.common import cache_utils
 from resources.lib.common.exceptions import (NotLoggedInError, MissingCredentialsError, WebsiteParsingError,
                                              MbrStatusAnonymousError, MetadataNotAvailable, LoginValidateError,
-                                             HttpError401, InvalidProfilesError, ErrorMsgNoReport)
+                                             InvalidProfilesError, ErrorMsgNoReport)
 from resources.lib.globals import G
 from resources.lib.kodi import ui
 from resources.lib.services.nfsession.session.path_requests import SessionPathRequests
@@ -96,37 +96,22 @@ class NFSessionOperations(SessionPathRequests):
     def activate_profile(self, guid):
         """Set the profile identified by guid as active"""
         LOG.debug('Switching to profile {}', guid)
-        current_active_guid = G.LOCAL_DB.get_active_profile_guid()
-        if guid == current_active_guid:
+        if guid == G.LOCAL_DB.get_active_profile_guid():
             LOG.info('The profile guid {} is already set, activation not needed.', guid)
             return
         if xbmc.Player().isPlayingVideo():
             # Change the current profile while a video is playing can cause problems with outgoing HTTP requests
             # (MSL/NFSession) causing a failure in the HTTP request or sending data on the wrong profile
             raise ErrorMsgNoReport('It is not possible select a profile while a video is playing.')
-        timestamp = time.time()
         LOG.info('Activating profile {}', guid)
-        # 20/05/2020 - The method 1 not more working for switching PIN locked profiles
-        # INIT Method 1 - HTTP mode
-        # response = self._get('switch_profile', params={'tkn': guid})
-        # self.nfsession.auth_url = self.website_extract_session_data(response)['auth_url']
-        # END Method 1
-        # INIT Method 2 - API mode
         try:
-            response = self.get_safe(endpoint='activate_profile',
-                                     params={'switchProfileGuid': guid,
-                                             '_': int(timestamp * 1000),
-                                             'authURL': self.auth_url})
-            if response.get('status') != 'success':
-                raise InvalidProfilesError('Unable to access to the selected profile.')
-        except HttpError401 as exc:
-            # Profile guid not more valid
+            # Use /SwitchProfile endpoint to switch the active profile server-side
+            self.get_safe('switch_profile', params={'tkn': guid})
+            # Fetch browse page to get a fresh authURL for the new profile
+            response = self.get_safe('browse')
+            self.auth_url = website.extract_session_data(response)['auth_url']
+        except Exception as exc:
             raise InvalidProfilesError('Unable to access to the selected profile.') from exc
-        # Retrieve browse page to update authURL
-        response = self.get_safe('browse')
-        self.auth_url = website.extract_session_data(response)['auth_url']
-        # END Method 2
-
         G.LOCAL_DB.switch_active_profile(guid)
         G.CACHE_MANAGEMENT.identifier_prefix = guid
         cookies.save(self.session.cookies)

--- a/resources/lib/services/nfsession/session/endpoints.py
+++ b/resources/lib/services/nfsession/session/endpoints.py
@@ -77,12 +77,6 @@ ENDPOINTS = {
          'use_default_params': False,
          'add_auth_url': None,
          'accept': '*/*'},
-    'activate_profile':
-        {'address': '/api/shakti/mre/profiles/switch',
-         'is_api_call': False,
-         'use_default_params': False,
-         'add_auth_url': None,
-         'accept': '*/*'},
     'profile_lock':
         {'address': '/api/shakti/mre/profileLock',
          'is_api_call': False,

--- a/resources/lib/services/nfsession/session/http_requests.py
+++ b/resources/lib/services/nfsession/session/http_requests.py
@@ -170,13 +170,15 @@ class SessionHTTPRequests(SessionBase):
         #                   it is still added in an 'empty' form in the response
         if endpoint_conf['use_default_params']:
             params = {
+                'webp': 'true',
                 'drmSystem': 'widevine',
-                'falcor_server': '0.1.0',
-                'withSize': 'false',
-                'materialize': 'false',
-                'routeAPIRequestsThroughFTL': 'false',
                 'isVolatileBillboardsEnabled': 'true',
                 'isTop10Supported': 'true',
+                'hasVideoMerchInBob': 'true',
+                'hasVideoMerchInJaw': 'true',
+                'falcor_server': '0.1.0',
+                'withSize': 'true',
+                'materialize': 'true',
                 'original_path': '/shakti/mre/pathEvaluator'
             }
         if endpoint_conf['add_auth_url'] == 'to_params':


### PR DESCRIPTION
# Summary

- Replace dead Netflix /api/shakti/mre/profiles/switch endpoint (returns 404) with /SwitchProfile endpoint for server-side profile switching
  - Fetch /browse after switch to obtain fresh authURL for the new profile
  - Remove unused activate_profile endpoint definition and http_requests_bak.py backup file

# Details

Netflix seems  to have removed the /api/shakti/mre/profiles/switch API, breaking profile switching with a 404 error. The /SwitchProfile?tkn=GUID endpoint was previously abandoned (May 2020) because it didn't work for PIN-locked profiles, but PIN verification is now handled separately in directory_utils.py:verify_profile_pin before activate_profile is called, making this limitation irrelevant.

# Test plan
  
 - Switch to a non-PIN-locked profile — switches without errors, content loads correctly
 - Switch back to the original profile

I did not test to switch to a PIN-locked profile — PIN prompt appears, switch works after entering correct PIN
  
# Tested on:
  - LibreELEC (Omega) 12.2.1
  - Ubuntu Linux 24.04 Kodi 20.5.0