### PR TITLE
Removing prk (per represenation key) from manifest

### DIFF
--- a/resources/lib/services/nfsession/msl/profiles.py
+++ b/resources/lib/services/nfsession/msl/profiles.py
@@ -80,8 +80,9 @@ PROFILES = {
 
 def enabled_profiles():
     """Return a list of all base and enabled additional profiles"""
+    # H.264 PRK-QC profiles can fail sample decryption in InputStream Adaptive/Widevine.
     return (PROFILES['base'] +
-            PROFILES['h264'] + PROFILES['h264_prk_qc'] +
+            PROFILES['h264'] +
             _subtitle_profiles() +
             _additional_profiles('vp9profile0', 'enable_vp9_profiles') +
             _additional_profiles('vp9profile2', ['enable_vp9_profiles', 'enable_vp9.2_profiles']) +


### PR DESCRIPTION
This is a "bug-fix" commit at least for some platforms. The commit removes the PRK (per representation key) option from the manifest sent to Netflix, which caused failures in playback (not starting at all, sound-only playback). Many users reported issues that might be related (see https://github.com/CastagnaIT/plugin.video.netflix/issues/1785). It seems that the remaining profiles are enough as for May 2026.

I have successfully (no breaking changes, just able to play more videos – series) tested on my boxes: 
* Arch, Kodi 21.3.0, netflix plugin: 1.23.5+matrix.1
* Ubuntu 24.04, flatpak Kodi 21.2, netflix plugin: 1.23.5+matrix.1

Playback of some (older) videos requires VP9 to be enabled (with 720p limit on older HW), otherwise sound-only playback. If possible, please test on other platforms before merging this in, I have no option to test on win/android/mac.
